### PR TITLE
Fix grpc-netty version 1.20 and above

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,4 @@ grailsVersion=3.2.9
 # Not really needed for this project, but anyway
 kafkaVersion="Unknown"
 grpcVersion=1.24.1
+protocVersion=3.10.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,3 +14,4 @@ developers=Graeme Rocher
 grailsVersion=3.2.9
 # Not really needed for this project, but anyway
 kafkaVersion="Unknown"
+grpcVersion=1.24.1

--- a/grpc-runtime/build.gradle
+++ b/grpc-runtime/build.gradle
@@ -30,7 +30,7 @@ dependencies {
 // compileJava.options.forkOptions.jvmArgs = ['-Xdebug', '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005']
 
 protobuf {
-    protoc { artifact = "com.google.protobuf:protoc:3.7.0" }
+    protoc { artifact = "com.google.protobuf:protoc:$protocVersion" }
     plugins {
         grpc { artifact = "io.grpc:protoc-gen-grpc-java:$grpcVersion" }
     }
@@ -49,7 +49,7 @@ sourceSets {
 }
 
 protobuf {
-    protoc { artifact = "com.google.protobuf:protoc:3.7.0" }
+    protoc { artifact = "com.google.protobuf:protoc:$protocVersion" }
     plugins {
         grpc { artifact = "io.grpc:protoc-gen-grpc-java:$grpcVersion" }
     }

--- a/grpc-runtime/build.gradle
+++ b/grpc-runtime/build.gradle
@@ -12,9 +12,9 @@ dependencies {
     compileOnly "io.micronaut:micronaut-discovery-client:$micronautVersion"
     compileOnly "io.micronaut:micronaut-tracing:$micronautVersion"
     compileOnly 'io.opentracing.contrib:opentracing-grpc:0.0.14'
-    compile "io.grpc:grpc-netty:1.19.0"
-	compile "io.grpc:grpc-protobuf:1.24.0"
-	compile "io.grpc:grpc-stub:1.24.0"
+    compile "io.grpc:grpc-netty:$grpcVersion"
+    compile "io.grpc:grpc-protobuf:$grpcVersion"
+    compile "io.grpc:grpc-stub:$grpcVersion"
 
     testCompile "io.micronaut:micronaut-discovery-client:$micronautVersion"
     testCompile 'io.opentracing:opentracing-mock:0.32.0-RC1'
@@ -32,7 +32,7 @@ dependencies {
 protobuf {
     protoc { artifact = "com.google.protobuf:protoc:3.7.0" }
     plugins {
-        grpc { artifact = "io.grpc:protoc-gen-grpc-java:1.24.0" }
+        grpc { artifact = "io.grpc:protoc-gen-grpc-java:$grpcVersion" }
     }
     generateProtoTasks {
         all()*.plugins { grpc {} }
@@ -51,7 +51,7 @@ sourceSets {
 protobuf {
     protoc { artifact = "com.google.protobuf:protoc:3.7.0" }
     plugins {
-        grpc { artifact = "io.grpc:protoc-gen-grpc-java:1.24.0" }
+        grpc { artifact = "io.grpc:protoc-gen-grpc-java:$grpcVersion" }
     }
     generateProtoTasks {
         all()*.plugins { grpc {} }

--- a/grpc-runtime/src/main/java/io/micronaut/grpc/server/GrpcServerConfiguration.java
+++ b/grpc-runtime/src/main/java/io/micronaut/grpc/server/GrpcServerConfiguration.java
@@ -51,7 +51,7 @@ public class GrpcServerConfiguration {
     public static final String HOST = PREFIX + ".host";
     public static final int DEFAULT_PORT = 50051;
 
-    @ConfigurationBuilder(prefixes = "")
+    @ConfigurationBuilder(prefixes = "", excludes = "protocolNegotiator")
     protected final NettyServerBuilder serverBuilder;
     private final int serverPort;
     private final String serverHost;

--- a/protobuff-support/build.gradle
+++ b/protobuff-support/build.gradle
@@ -25,5 +25,5 @@ dependencies {
 }
 
 protobuf {
-    protoc { artifact = "com.google.protobuf:protoc:3.7.0" }
+    protoc { artifact = "com.google.protobuf:protoc:$protocVersion" }
 }


### PR DESCRIPTION
The `ProtocolNegotiator` interface in [grpc-java](https://github.com/grpc/grpc-java/commit/8e6fa122a6b0021b2638436e7b55f29d09beda13) has been hidden in version `1.20` and is no longer configurable through [GrpcServerConfiguration](https://github.com/micronaut-projects/micronaut-grpc/blob/master/grpc-runtime/src/main/java/io/micronaut/grpc/server/GrpcServerConfiguration.java#L54-L55).

The current version of the plugin cannot be used in projects using dependencies compiled with grpc >= 1.20.0.

