### PR TITLE
Add ability to disable the gRPC server

### DIFF
--- a/grpc-runtime/src/main/java/io/micronaut/grpc/server/GrpcEmbeddedServer.java
+++ b/grpc-runtime/src/main/java/io/micronaut/grpc/server/GrpcEmbeddedServer.java
@@ -23,6 +23,7 @@ import io.micronaut.context.annotation.Secondary;
 import io.micronaut.context.event.ApplicationEventPublisher;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.util.ArgumentUtils;
+import io.micronaut.core.util.StringUtils;
 import io.micronaut.discovery.ServiceInstance;
 import io.micronaut.discovery.cloud.ComputeInstanceMetadata;
 import io.micronaut.discovery.cloud.ComputeInstanceMetadataResolver;
@@ -59,6 +60,7 @@ import static io.micronaut.core.io.socket.SocketUtils.LOCALHOST;
 @Singleton
 @Secondary
 @Requires(classes = ServerBuilder.class)
+@Requires(property = GrpcServerConfiguration.ENABLED, value = StringUtils.TRUE, defaultValue = StringUtils.TRUE)
 public class GrpcEmbeddedServer implements EmbeddedServer {
 
     private final ApplicationContext applicationContext;

--- a/grpc-runtime/src/main/java/io/micronaut/grpc/server/GrpcEmbeddedServerListener.java
+++ b/grpc-runtime/src/main/java/io/micronaut/grpc/server/GrpcEmbeddedServerListener.java
@@ -16,6 +16,7 @@
 package io.micronaut.grpc.server;
 
 import io.micronaut.context.BeanContext;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.event.ApplicationEventListener;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.runtime.server.EmbeddedServer;
@@ -35,6 +36,7 @@ import javax.inject.Singleton;
  */
 @Internal
 @Singleton
+@Requires(beans = GrpcEmbeddedServer.class)
 class GrpcEmbeddedServerListener implements ApplicationEventListener<ServerStartupEvent>, AutoCloseable {
     private static final Logger LOG = LoggerFactory.getLogger(GrpcEmbeddedServerListener.class);
 

--- a/grpc-runtime/src/main/java/io/micronaut/grpc/server/GrpcServerConfiguration.java
+++ b/grpc-runtime/src/main/java/io/micronaut/grpc/server/GrpcServerConfiguration.java
@@ -49,6 +49,7 @@ public class GrpcServerConfiguration {
     public static final String PREFIX = "grpc.server";
     public static final String PORT = PREFIX + ".port";
     public static final String HOST = PREFIX + ".host";
+    public static final String ENABLED = PREFIX + ".enabled";
     public static final int DEFAULT_PORT = 50051;
 
     @ConfigurationBuilder(prefixes = "", excludes = "protocolNegotiator")

--- a/grpc-runtime/src/test/groovy/io/micronaut/grpc/GrpcEmbeddedServerSpec.groovy
+++ b/grpc-runtime/src/test/groovy/io/micronaut/grpc/GrpcEmbeddedServerSpec.groovy
@@ -16,6 +16,7 @@
 package io.micronaut.grpc
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.exceptions.NoSuchBeanException
 import io.micronaut.discovery.event.ServiceReadyEvent
 import io.micronaut.discovery.event.ServiceStoppedEvent
 import io.micronaut.grpc.server.GrpcEmbeddedServer
@@ -81,6 +82,18 @@ class GrpcEmbeddedServerSpec extends Specification {
         conditions.eventually {
             embeddedServer.getServer().isTerminated()
         }
+
+    }
+
+    void "test server does not exist when disabled"() {
+
+        when:
+        ApplicationContext.run(GrpcEmbeddedServer, [
+                'grpc.server.enabled': false
+        ])
+
+        then:
+        thrown NoSuchBeanException
 
     }
 

--- a/src/main/docs/guide/server.adoc
+++ b/src/main/docs/guide/server.adoc
@@ -37,6 +37,8 @@ grpc:
             private-key: '/path/to/my.key'
 ----
 
+By default the GRPC server will be enabled. To disable the GRPC server, set `grpc.server.enabled` to false.
+
 Alternatively if you prefer programmatic configuration you can write a `BeanCreationListener` for example:
 
 .Configuring the ServerBuilder


### PR DESCRIPTION
#112 

This PR provides a new `grpc.server.enabled` setting that provide the ability to disable the gRPC server in specific environments