### PR TITLE
Explicitly uses IO's task executor service during the channel creation

### DIFF
--- a/grpc-client-runtime/src/main/java/io/micronaut/grpc/channels/GrpcDefaultManagedChannelConfiguration.java
+++ b/grpc-client-runtime/src/main/java/io/micronaut/grpc/channels/GrpcDefaultManagedChannelConfiguration.java
@@ -19,6 +19,7 @@ import io.grpc.NameResolver;
 import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.context.annotation.Primary;
 import io.micronaut.context.env.Environment;
+import io.micronaut.scheduling.TaskExecutors;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -47,7 +48,7 @@ public class GrpcDefaultManagedChannelConfiguration extends GrpcManagedChannelCo
     public GrpcDefaultManagedChannelConfiguration(
             String name,
             Environment env,
-            ExecutorService executorService) {
+            @Named(TaskExecutors.IO) ExecutorService executorService) {
         super(name, env, executorService);
     }
 

--- a/grpc-client-runtime/src/main/java/io/micronaut/grpc/channels/GrpcNamedManagedChannelConfiguration.java
+++ b/grpc-client-runtime/src/main/java/io/micronaut/grpc/channels/GrpcNamedManagedChannelConfiguration.java
@@ -19,9 +19,11 @@ import io.grpc.NameResolver;
 import io.micronaut.context.annotation.EachProperty;
 import io.micronaut.context.annotation.Parameter;
 import io.micronaut.context.env.Environment;
+import io.micronaut.scheduling.TaskExecutors;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
+import javax.inject.Named;
 import java.util.concurrent.ExecutorService;
 
 /**
@@ -42,7 +44,7 @@ public class GrpcNamedManagedChannelConfiguration extends GrpcManagedChannelConf
     public GrpcNamedManagedChannelConfiguration(
             @Parameter String name,
             Environment env,
-            ExecutorService executorService) {
+            @Named(TaskExecutors.IO) ExecutorService executorService) {
         super(name, env, executorService);
     }
 


### PR DESCRIPTION
Avoids having multiple ExecutorService bean candidates to fix #170 