### PR TITLE
Fix proto converted not respecting @Consumes annotation (#216)

### DIFF
--- a/protobuff-support/build.gradle
+++ b/protobuff-support/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     testImplementation "io.micronaut:micronaut-inject-groovy:$micronautVersion"
     testImplementation "io.micronaut:micronaut-inject-java:$micronautVersion"
     testImplementation "io.micronaut.test:micronaut-test-spock:1.2.3"
+    testImplementation "com.hubspot.jackson:jackson-datatype-protobuf:0.9.12"
 }
 
 protobuf {

--- a/protobuff-support/src/main/java/io/micronaut/protobuf/convert/ByteBufToProtoMessageConverter.java
+++ b/protobuff-support/src/main/java/io/micronaut/protobuf/convert/ByteBufToProtoMessageConverter.java
@@ -54,14 +54,15 @@ public class ByteBufToProtoMessageConverter implements TypeConverter<ByteBuf, Me
     public Optional<Message> convert(ByteBuf object, Class<Message> targetType, ConversionContext context) {
         return codec
                 .getMessageBuilder(targetType)
-                .flatMap(builder -> rehydrate(object, builder));
+                .flatMap(builder -> rehydrate(object, builder, context));
     }
 
-    private Optional<Message> rehydrate(ByteBuf object, Message.Builder builder) {
+    private Optional<Message> rehydrate(ByteBuf object, Message.Builder builder, ConversionContext context) {
         try {
-            builder.mergeFrom(new ByteBufInputStream(object.copy()), codec.getExtensionRegistry());
+            builder.mergeFrom(new ByteBufInputStream(object.copy(), true), codec.getExtensionRegistry());
             return Optional.of(builder.build());
         } catch (IOException e) {
+            context.reject(e);
             return Optional.empty();
         }
     }

--- a/protobuff-support/src/main/java/io/micronaut/protobuf/convert/ByteBufToProtoMessageConverter.java
+++ b/protobuff-support/src/main/java/io/micronaut/protobuf/convert/ByteBufToProtoMessageConverter.java
@@ -15,17 +15,19 @@
  */
 package io.micronaut.protobuf.convert;
 
+import java.io.IOException;
+import java.util.Optional;
+
+import javax.inject.Singleton;
+
 import com.google.protobuf.Message;
+
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.convert.ConversionContext;
 import io.micronaut.core.convert.TypeConverter;
 import io.micronaut.protobuf.codec.ProtobufferCodec;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
-
-import javax.inject.Singleton;
-import java.io.IOException;
-import java.util.Optional;
 
 /**
  * Converts Protocol buffer messages from Netty {@link ByteBuf}.
@@ -41,6 +43,7 @@ public class ByteBufToProtoMessageConverter implements TypeConverter<ByteBuf, Me
 
     /**
      * Default constructor.
+     *
      * @param codec The codec
      */
     public ByteBufToProtoMessageConverter(ProtobufferCodec codec) {
@@ -56,10 +59,10 @@ public class ByteBufToProtoMessageConverter implements TypeConverter<ByteBuf, Me
 
     private Optional<Message> rehydrate(ByteBuf object, Message.Builder builder) {
         try {
-            builder.mergeFrom(new ByteBufInputStream(object), codec.getExtensionRegistry());
+            builder.mergeFrom(new ByteBufInputStream(object.copy()), codec.getExtensionRegistry());
             return Optional.of(builder.build());
         } catch (IOException e) {
-            throw new IllegalStateException("Error parsing: " + e.getMessage());
+            return Optional.empty();
         }
     }
 }

--- a/protobuff-support/src/test/groovy/io/micronaut/BaseSpec.groovy
+++ b/protobuff-support/src/test/groovy/io/micronaut/BaseSpec.groovy
@@ -22,6 +22,7 @@ import io.micronaut.http.HttpRequest
 import io.micronaut.http.client.RxHttpClient
 import io.micronaut.protobuf.codec.ProtobufferCodec
 import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.websocket.RxWebSocketClient
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Specification
@@ -35,6 +36,13 @@ abstract class BaseSpec extends Specification {
     @AutoCleanup
     RxHttpClient rxHttpClient = embeddedServer.applicationContext.createBean(
             RxHttpClient,
+            embeddedServer.getURL()
+    )
+
+    @Shared
+    @AutoCleanup
+    RxWebSocketClient rxWebSocketClient = embeddedServer.applicationContext.createBean(
+            RxWebSocketClient,
             embeddedServer.getURL()
     )
 

--- a/protobuff-support/src/test/groovy/io/micronaut/SampleWebsocketClient.groovy
+++ b/protobuff-support/src/test/groovy/io/micronaut/SampleWebsocketClient.groovy
@@ -1,0 +1,25 @@
+package io.micronaut
+
+import com.example.wire.Example
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Consumes
+import io.micronaut.http.annotation.Produces
+import io.micronaut.websocket.annotation.ClientWebSocket
+import io.micronaut.websocket.annotation.OnMessage
+
+import java.util.concurrent.ConcurrentLinkedQueue
+
+@ClientWebSocket("/ws/echo")
+abstract class SampleWebsocketClient implements AutoCloseable {
+
+    Collection<Example.GeoPoint> replies = new ConcurrentLinkedQueue<>()
+
+    @OnMessage
+    @Consumes(MediaType.APPLICATION_JSON)
+    void onMessage(Example.GeoPoint message) {
+        replies.add(message)
+    }
+
+    @Produces(MediaType.APPLICATION_JSON)
+    abstract void sendJson(Example.GeoPoint geoPoint)
+}

--- a/protobuff-support/src/test/groovy/io/micronaut/SampleWebsocketHandler.groovy
+++ b/protobuff-support/src/test/groovy/io/micronaut/SampleWebsocketHandler.groovy
@@ -1,0 +1,21 @@
+package io.micronaut
+
+import com.example.wire.Example
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Body
+import io.micronaut.http.annotation.Consumes
+import io.micronaut.http.annotation.Produces
+import io.micronaut.websocket.WebSocketSession
+import io.micronaut.websocket.annotation.OnMessage
+import io.micronaut.websocket.annotation.ServerWebSocket
+
+@ServerWebSocket("/ws/echo")
+class SampleWebsocketHandler {
+
+    @OnMessage
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    void onMessage(WebSocketSession session, @Body Example.GeoPoint payload) {
+        session.sendSync(payload)
+    }
+}

--- a/protobuff-support/src/test/groovy/io/micronaut/SimpleWebsocketSpec.groovy
+++ b/protobuff-support/src/test/groovy/io/micronaut/SimpleWebsocketSpec.groovy
@@ -1,0 +1,22 @@
+package io.micronaut
+
+import com.example.wire.Example
+import spock.util.concurrent.PollingConditions
+
+class SimpleWebsocketSpec extends BaseSpec {
+
+    String url = embeddedServer.getURL().toString() + '/ws/echo'
+
+    void "test json from proto generated classes websocket exchange"() {
+        setup:
+            Example.GeoPoint message = SampleController.DUBLIN
+            SampleWebsocketClient sampleWebsocketClient = rxWebSocketClient.connect(SampleWebsocketClient, url).blockingFirst()
+            PollingConditions conditions = new PollingConditions(timeout: 15, delay: 0.5)
+        when: 'Json is sent over ws to the server=[#url]'
+            sampleWebsocketClient.sendJson(message)
+        then: 'Echoed message is parsed'
+            conditions.eventually {
+                sampleWebsocketClient.replies.contains(message)
+            }
+    }
+}


### PR DESCRIPTION
Fix ByteBufToProtoMessageConverter.java not respecting @Consumes annotation in websocket exchange. (#216)