### PR TITLE
Allow GrpcEmbeddedServer to await the termination of the server

### DIFF
--- a/grpc-server-runtime/src/main/java/io/micronaut/grpc/server/GrpcEmbeddedServer.java
+++ b/grpc-server-runtime/src/main/java/io/micronaut/grpc/server/GrpcEmbeddedServer.java
@@ -47,6 +47,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.micronaut.core.io.socket.SocketUtils.LOCALHOST;
@@ -199,6 +200,11 @@ public class GrpcEmbeddedServer implements EmbeddedServer {
                 }
             } finally {
                 server.shutdownNow();
+                try {
+                    server.awaitTermination(grpcConfiguration.getAwaitTermination().toMillis(), TimeUnit.MILLISECONDS);
+                } catch (InterruptedException ignored) {
+
+                }
             }
 
         }

--- a/grpc-server-runtime/src/main/java/io/micronaut/grpc/server/GrpcServerConfiguration.java
+++ b/grpc-server-runtime/src/main/java/io/micronaut/grpc/server/GrpcServerConfiguration.java
@@ -36,8 +36,10 @@ import javax.inject.Named;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
+import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Configuration for the GRPC server.
@@ -55,6 +57,7 @@ public class GrpcServerConfiguration {
     public static final String ENABLED = PREFIX + ".enabled";
     public static final String HEALTH_ENABLED = PREFIX + ".health.enabled";
     public static final int DEFAULT_PORT = 50051;
+    public static final Duration DEFAULT_AWAIT_TERMINATION = Duration.ofSeconds(30);
 
     @ConfigurationBuilder(prefixes = "", excludes = "protocolNegotiator")
     protected final NettyServerBuilder serverBuilder;
@@ -64,6 +67,7 @@ public class GrpcServerConfiguration {
     private GrpcSslConfiguration serverConfiguration = new GrpcSslConfiguration();
     private boolean secure = false;
     private String instanceId = "";
+    private Duration awaitTermination = DEFAULT_AWAIT_TERMINATION;
 
     /**
      * Constructor.
@@ -208,6 +212,20 @@ public class GrpcServerConfiguration {
     public @Nonnull GrpcSslConfiguration getServerConfiguration() {
         return serverConfiguration;
     }
+
+    /**
+     * Sets the maximum duration application will wait for the server to terminate and release all resources.
+     * @param awaitTermination The maximum duration the application will wait for the server to terminate.
+     */
+    public void setAwaitTermination(Duration awaitTermination) {
+        this.awaitTermination = awaitTermination;
+    }
+
+    /**
+     * Gets the maximum duration application will wait for the server to terminate and release all resources.
+     * @return The maximum duration the application will wait for the server to terminate.
+     */
+    public Duration getAwaitTermination() { return awaitTermination; }
 
     /**
      * Sets the SSL configuration.

--- a/grpc-server-runtime/src/main/java/io/micronaut/grpc/server/GrpcServerConfiguration.java
+++ b/grpc-server-runtime/src/main/java/io/micronaut/grpc/server/GrpcServerConfiguration.java
@@ -39,7 +39,6 @@ import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Configuration for the GRPC server.
@@ -225,7 +224,9 @@ public class GrpcServerConfiguration {
      * Gets the maximum duration application will wait for the server to terminate and release all resources.
      * @return The maximum duration the application will wait for the server to terminate.
      */
-    public Duration getAwaitTermination() { return awaitTermination; }
+    public Duration getAwaitTermination() {
+        return awaitTermination;
+    }
 
     /**
      * Sets the SSL configuration.


### PR DESCRIPTION
When the Application is terminated, the GrpcEmbeddedServer calls shutdownNow on the gRPC Server that it owns. While this intiaties forceful shutdown of the Server instance, it doesn't wait for the server to close all connections and release its resources. This results in client applications not receiving an UNAVAILABLE response (or a TCP FIN for that matter). For clients with long lived connections with few requests, the client is unaware of the closed connection until it attempts to send a request (resulting in a failure to flush the kernel send buffer alerting the client that the downstream server is closed). 

As GrpcEmbeddedServer already calls shutdownNow(), the amount of time that the application will have to wait for the gRPC Server to release its resources is short (see ServerImpl and NettyServerTransport in the gRPC source tree for details), so the application lifecycle should not be unduly encumbered with a long wait time by waiting for the resources to be released. 

This PR adds logic to await termination and externalizes a configuration parameter to control the maximum duration the application is willing to tolerate. 