### PR TITLE
Upgrade dependencies

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        graalvm: ['21.0.0.2.java8', '21.0.0.2.java11']
+        graalvm: ['21.1.0.java8', '21.1.0.java11']
     steps:
        # https://github.com/actions/virtual-environments/issues/709
       - name: Free disk space

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         maven { url "https://repo.grails.org/grails/core" }
     }
     dependencies {
-        classpath "io.micronaut.build.internal:micronaut-gradle-plugins:3.0.3"
+        classpath "io.micronaut.build.internal:micronaut-gradle-plugins:3.0.4"
     }
 }
 
@@ -28,4 +28,5 @@ subprojects { Project subproject ->
 
 apply plugin: "io.micronaut.build.internal.docs"
 apply plugin: "io.micronaut.build.internal.dependency-updates"
+
 dependencyUpdates.enabled = false

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,7 @@ spockVersion=2.0-groovy-3.0
 protobufJavaVersion=3.17.2
 grpcVersion=1.38.0
 protocVersion=3.17.2
+discoveryClientVersion=2.5.0
 
 title=Micronaut gRPC
 projectDesc=Integration between Micronaut and gRPC

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,13 +1,13 @@
-projectVersion=2.4.1-SNAPSHOT
-micronautDocsVersion=1.0.24
-micronautBuildVersion=1.1.5
-micronautVersion=2.4.2
-micronautTestVersion=2.3.1
-groovyVersion=3.0.4
-spockVersion=2.0-M3-groovy-3.0
-protobufJavaVersion=3.14.0
+projectVersion=2.5.0-SNAPSHOT
+micronautDocsVersion=1.0.25
+micronautVersion=2.5.5
+micronautTestVersion=2.3.6
+
+groovyVersion=3.0.8
+spockVersion=2.0-groovy-3.0
+protobufJavaVersion=3.17.2
 grpcVersion=1.38.0
-protocVersion=3.14.0
+protocVersion=3.17.2
 
 title=Micronaut gRPC
 projectDesc=Integration between Micronaut and gRPC

--- a/grpc-client-runtime/build.gradle
+++ b/grpc-client-runtime/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     testImplementation 'io.jaegertracing:jaeger-core:1.6.0'
     testImplementation "io.micronaut:micronaut-inject-groovy:$micronautVersion"
     testImplementation "io.micronaut:micronaut-inject-java:$micronautVersion"
-    testImplementation 'io.micronaut.test:micronaut-test-spock:2.3.3'
+    testImplementation "io.micronaut.test:micronaut-test-spock:$micronautTestVersion"
     testImplementation project(":grpc-server-runtime")
 }
 

--- a/grpc-client-runtime/build.gradle
+++ b/grpc-client-runtime/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'com.google.protobuf' version '0.8.16'
 }
 dependencies {
-	annotationProcessor "io.micronaut:micronaut-inject-java:$micronautVersion"
+    annotationProcessor "io.micronaut:micronaut-inject-java:$micronautVersion"
     annotationProcessor "io.micronaut.docs:micronaut-docs-asciidoc-config-props:$micronautDocsVersion"    
     compileOnly "io.micronaut:micronaut-inject-java:$micronautVersion"
     api project(":grpc-annotation")

--- a/grpc-client-runtime/build.gradle
+++ b/grpc-client-runtime/build.gradle
@@ -12,11 +12,11 @@ dependencies {
     api "io.grpc:grpc-protobuf:$grpcVersion"
     api "io.grpc:grpc-stub:$grpcVersion"
     implementation "io.grpc:grpc-netty:$grpcVersion"
-    compileOnly "io.micronaut.discovery:micronaut-discovery-client:2.3.0"
+    compileOnly "io.micronaut.discovery:micronaut-discovery-client:$discoveryClientVersion"
     compileOnly "io.micronaut:micronaut-tracing:$micronautVersion"
     compileOnly 'io.opentracing.contrib:opentracing-grpc:0.2.3'
 
-    testImplementation "io.micronaut.discovery:micronaut-discovery-client:2.2.4"
+    testImplementation "io.micronaut.discovery:micronaut-discovery-client:$discoveryClientVersion"
     testImplementation 'io.opentracing:opentracing-mock:0.33.0'
     testImplementation "io.micronaut:micronaut-tracing:$micronautVersion"
     testImplementation 'io.opentracing.contrib:opentracing-grpc:0.2.3'

--- a/grpc-client-runtime/src/main/java/io/micronaut/grpc/channels/GrpcDefaultManagedChannelConfiguration.java
+++ b/grpc-client-runtime/src/main/java/io/micronaut/grpc/channels/GrpcDefaultManagedChannelConfiguration.java
@@ -19,9 +19,9 @@ import io.grpc.NameResolver;
 import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.context.annotation.Primary;
 import io.micronaut.context.env.Environment;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.scheduling.TaskExecutors;
 
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
 import java.util.concurrent.ExecutorService;

--- a/grpc-client-runtime/src/main/java/io/micronaut/grpc/channels/GrpcManagedChannelConfiguration.java
+++ b/grpc-client-runtime/src/main/java/io/micronaut/grpc/channels/GrpcManagedChannelConfiguration.java
@@ -19,9 +19,9 @@ import io.grpc.NameResolver;
 import io.grpc.netty.NettyChannelBuilder;
 import io.micronaut.context.annotation.ConfigurationBuilder;
 import io.micronaut.context.env.Environment;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.naming.Named;
 
-import javax.annotation.Nullable;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.URI;

--- a/grpc-client-runtime/src/main/java/io/micronaut/grpc/channels/GrpcNamedManagedChannelConfiguration.java
+++ b/grpc-client-runtime/src/main/java/io/micronaut/grpc/channels/GrpcNamedManagedChannelConfiguration.java
@@ -19,9 +19,9 @@ import io.grpc.NameResolver;
 import io.micronaut.context.annotation.EachProperty;
 import io.micronaut.context.annotation.Parameter;
 import io.micronaut.context.env.Environment;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.scheduling.TaskExecutors;
 
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
 import java.util.concurrent.ExecutorService;

--- a/grpc-client-runtime/src/main/java/io/micronaut/grpc/client/tracing/GrpcClientTracingInterceptorConfiguration.java
+++ b/grpc-client-runtime/src/main/java/io/micronaut/grpc/client/tracing/GrpcClientTracingInterceptorConfiguration.java
@@ -17,12 +17,14 @@ package io.micronaut.grpc.client.tracing;
 
 import io.micronaut.context.annotation.ConfigurationBuilder;
 import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.grpc.channels.GrpcDefaultManagedChannelConfiguration;
 import io.opentracing.Tracer;
-import io.opentracing.contrib.grpc.*;
+import io.opentracing.contrib.grpc.ClientCloseDecorator;
+import io.opentracing.contrib.grpc.ClientSpanDecorator;
+import io.opentracing.contrib.grpc.TracingClientInterceptor;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 
 /**
@@ -51,7 +53,7 @@ public class GrpcClientTracingInterceptorConfiguration {
     /**
      * @return The {@link TracingClientInterceptor.Builder}
      */
-    public @Nonnull TracingClientInterceptor.Builder getBuilder() {
+    public @NonNull TracingClientInterceptor.Builder getBuilder() {
         return builder;
     }
 

--- a/grpc-client-runtime/src/main/java/io/micronaut/grpc/client/tracing/GrpcClientTracingInterceptorFactory.java
+++ b/grpc-client-runtime/src/main/java/io/micronaut/grpc/client/tracing/GrpcClientTracingInterceptorFactory.java
@@ -19,8 +19,8 @@ import io.grpc.ClientInterceptor;
 import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.NonNull;
 
-import javax.annotation.Nonnull;
 import javax.inject.Singleton;
 
 /**
@@ -39,7 +39,7 @@ public class GrpcClientTracingInterceptorFactory {
     @Requires(beans = GrpcClientTracingInterceptorConfiguration.class)
     @Singleton
     @Bean
-    protected @Nonnull ClientInterceptor clientTracingInterceptor(@Nonnull GrpcClientTracingInterceptorConfiguration configuration) {
+    protected @NonNull ClientInterceptor clientTracingInterceptor(@NonNull GrpcClientTracingInterceptorConfiguration configuration) {
         return configuration.getBuilder().build();
     }
 }

--- a/grpc-client-runtime/src/main/java/io/micronaut/grpc/discovery/GrpcNameResolverProvider.java
+++ b/grpc-client-runtime/src/main/java/io/micronaut/grpc/discovery/GrpcNameResolverProvider.java
@@ -15,10 +15,10 @@
  */
 package io.micronaut.grpc.discovery;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
 import io.grpc.*;
 import io.micronaut.context.LifeCycle;
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;

--- a/grpc-server-runtime/build.gradle
+++ b/grpc-server-runtime/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     testImplementation 'io.jaegertracing:jaeger-core:1.6.0'
     testImplementation "io.micronaut:micronaut-inject-groovy:$micronautVersion"
     testImplementation "io.micronaut:micronaut-inject-java:$micronautVersion"
-    testImplementation 'io.micronaut.test:micronaut-test-spock:2.3.3'
+    testImplementation "io.micronaut.test:micronaut-test-spock:$micronautTestVersion"
     testImplementation "io.micronaut:micronaut-management"
     testImplementation project(":grpc-client-runtime")
 

--- a/grpc-server-runtime/build.gradle
+++ b/grpc-server-runtime/build.gradle
@@ -12,12 +12,12 @@ dependencies {
     api "io.grpc:grpc-protobuf:$grpcVersion"
     api "io.grpc:grpc-stub:$grpcVersion"
 
-    compileOnly "io.micronaut.discovery:micronaut-discovery-client:2.3.0"
+    compileOnly "io.micronaut.discovery:micronaut-discovery-client:$discoveryClientVersion"
     compileOnly "io.micronaut:micronaut-tracing:$micronautVersion"
     compileOnly "io.micronaut:micronaut-management"
     compileOnly 'io.opentracing.contrib:opentracing-grpc:0.2.3'
 
-    testImplementation "io.micronaut.discovery:micronaut-discovery-client:2.2.4"
+    testImplementation "io.micronaut.discovery:micronaut-discovery-client:$discoveryClientVersion"
     testImplementation 'io.opentracing:opentracing-mock:0.33.0'
     testImplementation "io.micronaut:micronaut-tracing:$micronautVersion"
     testImplementation 'io.opentracing.contrib:opentracing-grpc:0.2.3'

--- a/grpc-server-runtime/src/main/java/io/micronaut/grpc/server/GrpcEmbeddedServer.java
+++ b/grpc-server-runtime/src/main/java/io/micronaut/grpc/server/GrpcEmbeddedServer.java
@@ -22,6 +22,8 @@ import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.annotation.Secondary;
 import io.micronaut.context.event.ApplicationEventPublisher;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.discovery.ServiceInstance;
@@ -36,8 +38,6 @@ import io.micronaut.runtime.server.EmbeddedServer;
 import io.micronaut.runtime.server.event.ServerShutdownEvent;
 import io.micronaut.runtime.server.event.ServerStartupEvent;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.inject.Singleton;
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -86,11 +86,11 @@ public class GrpcEmbeddedServer implements EmbeddedServer {
      */
     @Internal
     GrpcEmbeddedServer(
-            @Nonnull ApplicationContext applicationContext,
-            @Nonnull ApplicationConfiguration applicationConfiguration,
-            @Nonnull GrpcServerConfiguration grpcServerConfiguration,
-            @Nonnull ServerBuilder<?> serverBuilder,
-            @Nonnull ApplicationEventPublisher eventPublisher,
+            @NonNull ApplicationContext applicationContext,
+            @NonNull ApplicationConfiguration applicationConfiguration,
+            @NonNull GrpcServerConfiguration grpcServerConfiguration,
+            @NonNull ServerBuilder<?> serverBuilder,
+            @NonNull ApplicationEventPublisher eventPublisher,
             @Nullable ComputeInstanceMetadataResolver computeInstanceMetadataResolver,
             @Nullable List<ServiceInstanceMetadataContributor> metadataContributors) {
         ArgumentUtils.requireNonNull("applicationContext", applicationContext);
@@ -108,14 +108,14 @@ public class GrpcEmbeddedServer implements EmbeddedServer {
     /**
      * @return The underlying GRPC {@link Server}.
      */
-    public @Nonnull Server getServer() {
+    public @NonNull Server getServer() {
         return server;
     }
 
     /**
      * @return The configuration for the server
      */
-    public @Nonnull GrpcServerConfiguration getServerConfiguration() {
+    public @NonNull GrpcServerConfiguration getServerConfiguration() {
         return grpcConfiguration;
     }
 

--- a/grpc-server-runtime/src/main/java/io/micronaut/grpc/server/GrpcServerBuilder.java
+++ b/grpc-server-runtime/src/main/java/io/micronaut/grpc/server/GrpcServerBuilder.java
@@ -21,10 +21,10 @@ import io.grpc.ServerInterceptor;
 import io.grpc.ServerTransportFilter;
 import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Factory;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.order.OrderUtil;
 import io.micronaut.core.util.CollectionUtils;
 
-import javax.annotation.Nullable;
 import javax.inject.Singleton;
 import java.util.List;
 

--- a/grpc-server-runtime/src/main/java/io/micronaut/grpc/server/GrpcServerConfiguration.java
+++ b/grpc-server-runtime/src/main/java/io/micronaut/grpc/server/GrpcServerConfiguration.java
@@ -24,13 +24,13 @@ import io.micronaut.context.annotation.Property;
 import io.micronaut.context.env.Environment;
 import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.core.annotation.Creator;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.convert.format.ReadableBytes;
 import io.micronaut.core.io.ResourceResolver;
 import io.micronaut.core.io.socket.SocketUtils;
 import io.micronaut.scheduling.TaskExecutors;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
 import java.io.IOException;
@@ -127,7 +127,7 @@ public class GrpcServerConfiguration {
      * The server builder.
      * @return The {@link ServerBuilder}
      */
-    public @Nonnull ServerBuilder<?> getServerBuilder() {
+    public @NonNull ServerBuilder<?> getServerBuilder() {
         return serverBuilder;
     }
 
@@ -151,7 +151,7 @@ public class GrpcServerConfiguration {
      * The instance id.
      * @return The instance id
      */
-    public @Nonnull String getInstanceId() {
+    public @NonNull String getInstanceId() {
         return instanceId;
     }
 
@@ -208,7 +208,7 @@ public class GrpcServerConfiguration {
      * The SSL configuration.
      * @return The SSL configuration
      */
-    public @Nonnull GrpcSslConfiguration getServerConfiguration() {
+    public @NonNull GrpcSslConfiguration getServerConfiguration() {
         return serverConfiguration;
     }
 

--- a/grpc-server-runtime/src/main/java/io/micronaut/grpc/server/GrpcServerInstance.java
+++ b/grpc-server-runtime/src/main/java/io/micronaut/grpc/server/GrpcServerInstance.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.grpc.server;
 
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.convert.value.ConvertibleValues;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
@@ -22,7 +23,6 @@ import io.micronaut.discovery.EmbeddedServerInstance;
 import io.micronaut.discovery.metadata.ServiceInstanceMetadataContributor;
 import io.micronaut.runtime.server.EmbeddedServer;
 
-import javax.annotation.Nullable;
 import java.net.URI;
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/grpc-server-runtime/src/main/java/io/micronaut/grpc/server/GrpcSslConfiguration.java
+++ b/grpc-server-runtime/src/main/java/io/micronaut/grpc/server/GrpcSslConfiguration.java
@@ -16,8 +16,8 @@
 package io.micronaut.grpc.server;
 
 import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.annotation.Nullable;
 
-import javax.annotation.Nullable;
 import java.util.Optional;
 
 /**

--- a/grpc-server-runtime/src/main/java/io/micronaut/grpc/server/tracing/GrpcServerTracingInterceptorConfiguration.java
+++ b/grpc-server-runtime/src/main/java/io/micronaut/grpc/server/tracing/GrpcServerTracingInterceptorConfiguration.java
@@ -17,14 +17,14 @@ package io.micronaut.grpc.server.tracing;
 
 import io.micronaut.context.annotation.ConfigurationBuilder;
 import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.grpc.server.GrpcServerConfiguration;
 import io.opentracing.Tracer;
 import io.opentracing.contrib.grpc.ServerCloseDecorator;
 import io.opentracing.contrib.grpc.ServerSpanDecorator;
 import io.opentracing.contrib.grpc.TracingServerInterceptor;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 
 /**
@@ -53,7 +53,7 @@ public class GrpcServerTracingInterceptorConfiguration {
     /**
      * @return The {@link TracingServerInterceptor.Builder}
      */
-    public @Nonnull TracingServerInterceptor.Builder getBuilder() {
+    public @NonNull TracingServerInterceptor.Builder getBuilder() {
         return builder;
     }
 

--- a/grpc-server-runtime/src/main/java/io/micronaut/grpc/server/tracing/GrpcServerTracingInterceptorFactory.java
+++ b/grpc-server-runtime/src/main/java/io/micronaut/grpc/server/tracing/GrpcServerTracingInterceptorFactory.java
@@ -19,8 +19,8 @@ import io.grpc.ServerInterceptor;
 import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.NonNull;
 
-import javax.annotation.Nonnull;
 import javax.inject.Singleton;
 
 /**
@@ -40,7 +40,7 @@ public class GrpcServerTracingInterceptorFactory {
     @Requires(beans = GrpcServerTracingInterceptorConfiguration.class)
     @Singleton
     @Bean
-    protected @Nonnull ServerInterceptor serverTracingInterceptor(@Nonnull GrpcServerTracingInterceptorConfiguration configuration) {
+    protected @NonNull ServerInterceptor serverTracingInterceptor(@NonNull GrpcServerTracingInterceptorConfiguration configuration) {
         return configuration.getBuilder().build();
     }
 }

--- a/grpc-server-runtime/src/test/groovy/io/micronaut/grpc/server/health/GrpcServerHealthIndicatorSpec.groovy
+++ b/grpc-server-runtime/src/test/groovy/io/micronaut/grpc/server/health/GrpcServerHealthIndicatorSpec.groovy
@@ -1,25 +1,14 @@
 package io.micronaut.grpc.server.health
 
-import io.grpc.ServerBuilder
 import io.micronaut.context.ApplicationContext
-import io.micronaut.context.annotation.Replaces
-import io.micronaut.context.event.ApplicationEventPublisher
 import io.micronaut.core.io.socket.SocketUtils
-import io.micronaut.discovery.cloud.ComputeInstanceMetadataResolver
-import io.micronaut.discovery.metadata.ServiceInstanceMetadataContributor
+import io.micronaut.core.util.CollectionUtils
 import io.micronaut.grpc.server.GrpcEmbeddedServer
-import io.micronaut.grpc.server.GrpcServerConfiguration
 import io.micronaut.health.HealthStatus
 import io.micronaut.management.health.indicator.HealthResult
-import io.micronaut.runtime.ApplicationConfiguration
 import io.reactivex.internal.subscribers.BlockingFirstSubscriber
 import spock.lang.Specification
-import spock.lang.Unroll;
-import io.micronaut.core.util.CollectionUtils
-
-import javax.annotation.Nonnull
-import javax.annotation.Nullable
-import javax.inject.Singleton;
+import spock.lang.Unroll
 
 class GrpcServerHealthIndicatorSpec extends Specification {
     void "test grpc health indicator - UP"() {

--- a/protobuff-support/build.gradle
+++ b/protobuff-support/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     testImplementation "io.micronaut:micronaut-http-client:$micronautVersion"
     testImplementation "io.micronaut:micronaut-inject-groovy:$micronautVersion"
     testImplementation "io.micronaut:micronaut-inject-java:$micronautVersion"
-    testImplementation "io.micronaut.test:micronaut-test-spock:2.3.3"
+    testImplementation "io.micronaut.test:micronaut-test-spock:$micronautTestVersion"
     testImplementation "com.hubspot.jackson:jackson-datatype-protobuf:0.9.12"
 }
 


### PR DESCRIPTION
This PRs upgrades the dependencies: Micronaut, Spock, Groovy, Protobuf,...

It doesn't upgrade to Gradle 7 because it seems the Gradle protobuf plugin is not compatible yet. When trying to do the upgrade it fails with:

```
> Task :grpc-client-runtime:compileJava FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Some problems were found with the configuration of task ':grpc-client-runtime:compileJava' (type 'JavaCompile').
  - Type 'org.gradle.api.tasks.compile.JavaCompile' property 'options.compilerArgumentProviders.apt$0.name' is missing an input or output annotation.
    
    Reason: A property without annotation isn't considered during up-to-date checking.
    
    Possible solutions:
      1. Add an input or output annotation.
      2. Mark it as @Internal.
    
    Please refer to https://docs.gradle.org/7.0.2/userguide/validation_problems.html#missing_annotation for more details about this problem.
  - Type 'org.gradle.api.tasks.compile.JavaCompile' property 'options.compilerArgumentProviders.apt$0.publicType' is missing an input or output annotation.
    
    Reason: A property without annotation isn't considered during up-to-date checking.
    
    Possible solutions:
      1. Add an input or output annotation.
      2. Mark it as @Internal.
    
    Please refer to https://docs.gradle.org/7.0.2/userguide/validation_problems.html#missing_annotation for more details about this problem.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org
```