### PR TITLE
Move grpc-stub back to api scope

### DIFF
--- a/grpc-client-runtime/build.gradle
+++ b/grpc-client-runtime/build.gradle
@@ -9,9 +9,9 @@ dependencies {
     api "io.micronaut:micronaut-inject"
     api "io.micronaut:micronaut-runtime"
     api "io.grpc:grpc-protobuf:$grpcVersion"
+    api "io.grpc:grpc-stub:$grpcVersion"
 
     implementation "io.grpc:grpc-netty:$grpcVersion"
-    implementation "io.grpc:grpc-stub:$grpcVersion"
     implementation "io.projectreactor:reactor-core"
     implementation "jakarta.inject:jakarta.inject-api"
 

--- a/grpc-server-runtime/build.gradle
+++ b/grpc-server-runtime/build.gradle
@@ -9,9 +9,9 @@ dependencies {
     api "io.micronaut:micronaut-inject"
     api "io.micronaut:micronaut-runtime"
     api "io.grpc:grpc-protobuf:$grpcVersion"
+    api "io.grpc:grpc-stub:$grpcVersion"
 
     implementation "io.grpc:grpc-netty:$grpcVersion"
-    implementation "io.grpc:grpc-stub:$grpcVersion"
     implementation "jakarta.inject:jakarta.inject-api"
 
     compileOnly "io.micronaut.discovery:micronaut-discovery-client"


### PR DESCRIPTION
PR #406 changed the scope of `grpc-stub` to `implementation`. As a result, consumer applications don't include the dependency and they fail to compile.

The right fix is probably include that dependency as `compileOnly` in Launch, but we can't do that yet because it's a breaking change. This PR reverts that change.

Fixes https://github.com/micronaut-projects/micronaut-starter/issues/971