### PR TITLE
Fix GraalVM warnings

### DIFF
--- a/grpc-client-runtime/src/main/resources/META-INF/native-image/io.micronaut.grpc/micronaut-grpc-client-runtime/native-image.properties
+++ b/grpc-client-runtime/src/main/resources/META-INF/native-image/io.micronaut.grpc/micronaut-grpc-client-runtime/native-image.properties
@@ -1,1 +1,17 @@
-Args = --initialize-at-run-time=com.google.protobuf.ExtensionRegistryFactory,io.netty.util.internal.logging.Log4JLogger,io.netty.handler.ssl.ReferenceCountedOpenSslContext,io.netty.handler.ssl.JdkNpnApplicationProtocolNegotiator,io.netty.handler.ssl.ReferenceCountedOpenSslEngine,io.netty.handler.ssl.ConscryptAlpnSslEngine,io.netty.handler.ssl.JettyAlpnSslEngine$ClientEngine,io.netty.handler.ssl.JettyNpnSslEngine
+#
+# Copyright 2017-2021 original authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Args = --initialize-at-run-time=com.google.protobuf.ExtensionRegistryFactory,io.netty.util.internal.logging.Log4JLogger,io.netty.handler.ssl.ReferenceCountedOpenSslContext,io.netty.handler.ssl.JdkNpnApplicationProtocolNegotiator,io.netty.handler.ssl.ReferenceCountedOpenSslEngine,io.netty.handler.ssl.ConscryptAlpnSslEngine,io.netty.handler.ssl.JettyAlpnSslEngine$ClientEngine,io.netty.handler.ssl.JettyNpnSslEngine,io.micronaut.grpc.client.tracing.$GrpcClientTracingInterceptorConfiguration$Definition

--- a/grpc-server-runtime/src/main/resources/META-INF/native-image/io.micronaut.grpc/micronaut-grpc-server-runtime/native-image.properties
+++ b/grpc-server-runtime/src/main/resources/META-INF/native-image/io.micronaut.grpc/micronaut-grpc-server-runtime/native-image.properties
@@ -1,1 +1,17 @@
-Args = --initialize-at-run-time=com.google.protobuf.ExtensionRegistryFactory,io.netty.util.internal.logging.Log4JLogger,io.netty.handler.ssl.ReferenceCountedOpenSslContext,io.netty.handler.ssl.JdkNpnApplicationProtocolNegotiator,io.netty.handler.ssl.ReferenceCountedOpenSslEngine,io.netty.handler.ssl.ConscryptAlpnSslEngine,io.netty.handler.ssl.JettyAlpnSslEngine$ServerEngine,io.netty.handler.ssl.JettyNpnSslEngine,io.netty.handler.ssl.JettyAlpnSslEngine$ClientEngine
+#
+# Copyright 2017-2021 original authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Args = --initialize-at-run-time=com.google.protobuf.ExtensionRegistryFactory,io.netty.util.internal.logging.Log4JLogger,io.netty.handler.ssl.ReferenceCountedOpenSslContext,io.netty.handler.ssl.JdkNpnApplicationProtocolNegotiator,io.netty.handler.ssl.ReferenceCountedOpenSslEngine,io.netty.handler.ssl.ConscryptAlpnSslEngine,io.netty.handler.ssl.JettyAlpnSslEngine$ServerEngine,io.netty.handler.ssl.JettyNpnSslEngine,io.netty.handler.ssl.JettyAlpnSslEngine$ClientEngine,io.micronaut.grpc.server.health.$GrpcServerHealthIndicator$Definition,io.micronaut.grpc.server.tracing.$GrpcServerTracingInterceptorConfiguration$Definition,io.netty.handler.ssl.BouncyCastleAlpnSslUtils


### PR DESCRIPTION
This PR fixes the following warnings an error with GraalVM:

```
Warning: class initialization of class io.micronaut.grpc.server.health.$GrpcServerHealthIndicator$Definition failed with exception java.lang.NoClassDefFoundError: io/micronaut/management/health/indicator/HealthIndicator. This class will be initialized at run time because option --allow-incomplete-classpath is used for image building. Use the option --initialize-at-run-time=io.micronaut.grpc.server.health.$GrpcServerHealthIndicator$Definition to explicitly request delayed initialization of this class.
Warning: class initialization of class io.micronaut.grpc.server.tracing.$GrpcServerTracingInterceptorConfiguration$Definition failed with exception java.lang.NoClassDefFoundError: io/opentracing/contrib/grpc/ServerSpanDecorator. This class will be initialized at run time because option --allow-incomplete-classpath is used for image building. Use the option --initialize-at-run-time=io.micronaut.grpc.server.tracing.$GrpcServerTracingInterceptorConfiguration$Definition to explicitly request delayed initialization of this class.
Warning: class initialization of class io.micronaut.grpc.client.tracing.$GrpcClientTracingInterceptorConfiguration$Definition failed with exception java.lang.NoClassDefFoundError: io/opentracing/contrib/grpc/ClientSpanDecorator. This class will be initialized at run time because option --allow-incomplete-classpath is used for image building. Use the option --initialize-at-run-time=io.micronaut.grpc.client.tracing.$GrpcClientTracingInterceptorConfiguration$Definition to explicitly request delayed initialization of this class.
00:18:45.504 [ForkJoinPool-2-worker-3] ERROR i.n.h.ssl.BouncyCastleAlpnSslUtils - Unable to initialize BouncyCastleAlpnSslUtils.
java.lang.ClassNotFoundException: org.bouncycastle.jsse.BCSSLEngine
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:476)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:589)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:315)
	at io.netty.handler.ssl.BouncyCastleAlpnSslUtils.<clinit>(BouncyCastleAlpnSslUtils.java:63)
	at java.base/jdk.internal.misc.Unsafe.ensureClassInitialized0(Native Method)
	at java.base/jdk.internal.misc.Unsafe.ensureClassInitialized(Unsafe.java:1042)
	at jdk.unsupported/sun.misc.Unsafe.ensureClassInitialized(Unsafe.java:698)
	at jdk.internal.vm.compiler/org.graalvm.compiler.serviceprovider.GraalUnsafeAccess.ensureClassInitialized(GraalUnsafeAccess.java:77)
	at com.oracle.svm.hosted.classinitialization.ConfigurableClassInitialization.ensureClassInitialized(ConfigurableClassInitialization.java:178)
	at com.oracle.svm.hosted.classinitialization.ConfigurableClassInitialization.computeInitKindAndMaybeInitializeClass(ConfigurableClassInitialization.java:648)
	at com.oracle.svm.hosted.classinitialization.ConfigurableClassInitialization.computeInitKindAndMaybeInitializeClass(ConfigurableClassInitialization.java:131)
	at com.oracle.svm.hosted.classinitialization.ConfigurableClassInitialization.shouldInitializeAtRuntime(ConfigurableClassInitialization.java:159)
	at com.oracle.svm.hosted.SVMHost.isInitialized(SVMHost.java:308)
	at com.oracle.graal.pointsto.meta.AnalysisType.isInitialized(AnalysisType.java:723)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.maybeEagerlyInitialize(BytecodeParser.java:4435)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.genInvokeStatic(BytecodeParser.java:1659)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.genInvokeStatic(BytecodeParser.java:1652)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.processBytecode(BytecodeParser.java:5419)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.iterateBytecodesForBlock(BytecodeParser.java:3477)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.handleBytecodeBlock(BytecodeParser.java:3437)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.processBlock(BytecodeParser.java:3282)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.build(BytecodeParser.java:1145)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.buildRootMethod(BytecodeParser.java:1030)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.GraphBuilderPhase$Instance.run(GraphBuilderPhase.java:84)
	at com.oracle.svm.hosted.phases.SharedGraphBuilderPhase.run(SharedGraphBuilderPhase.java:81)
	at jdk.internal.vm.compiler/org.graalvm.compiler.phases.Phase.run(Phase.java:49)
	at jdk.internal.vm.compiler/org.graalvm.compiler.phases.BasePhase.apply(BasePhase.java:212)
	at jdk.internal.vm.compiler/org.graalvm.compiler.phases.Phase.apply(Phase.java:42)
	at jdk.internal.vm.compiler/org.graalvm.compiler.phases.Phase.apply(Phase.java:38)
	at com.oracle.graal.pointsto.flow.AnalysisParsedGraph.parseBytecode(AnalysisParsedGraph.java:132)
	at com.oracle.graal.pointsto.meta.AnalysisMethod.ensureGraphParsed(AnalysisMethod.java:621)
	at com.oracle.graal.pointsto.flow.MethodTypeFlowBuilder.parse(MethodTypeFlowBuilder.java:163)
	at com.oracle.graal.pointsto.flow.MethodTypeFlowBuilder.apply(MethodTypeFlowBuilder.java:321)
	at com.oracle.graal.pointsto.flow.MethodTypeFlow.createTypeFlow(MethodTypeFlow.java:293)
	at com.oracle.graal.pointsto.flow.MethodTypeFlow.ensureTypeFlowCreated(MethodTypeFlow.java:282)
	at com.oracle.graal.pointsto.flow.MethodTypeFlow.addContext(MethodTypeFlow.java:103)
	at com.oracle.graal.pointsto.DefaultAnalysisPolicy$DefaultVirtualInvokeTypeFlow.onObservedUpdate(DefaultAnalysisPolicy.java:222)
	at com.oracle.graal.pointsto.flow.TypeFlow.notifyObservers(TypeFlow.java:490)
	at com.oracle.graal.pointsto.flow.TypeFlow.update(TypeFlow.java:559)
	at com.oracle.graal.pointsto.PointsToAnalysis$2.run(PointsToAnalysis.java:595)
	at com.oracle.graal.pointsto.util.CompletionExecutor.executeCommand(CompletionExecutor.java:188)
	at com.oracle.graal.pointsto.util.CompletionExecutor.lambda$executeService$0(CompletionExecutor.java:172)
	at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1426)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
```