### PR TITLE
Fix for M1 Apple hardware

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-managed-grpc = '1.39.0'
-managed-protobuf = '3.17.2'
+managed-grpc = '1.45.0'
+managed-protobuf = '3.19.4'
 
 jackson-datatype-protobuf = '0.9.12'
 jaeger-core = '1.8.0'

--- a/grpc-client-runtime/src/main/java/io/micronaut/grpc/discovery/GrpcNameResolverProvider.java
+++ b/grpc-client-runtime/src/main/java/io/micronaut/grpc/discovery/GrpcNameResolverProvider.java
@@ -97,7 +97,12 @@ public class GrpcNameResolverProvider extends NameResolverProvider implements Li
 
     @Override
     public NameResolver newNameResolver(URI targetUri, NameResolver.Args args) {
-        final String serviceId = targetUri.toString();
+        // If the targetUri comes in prefixed with just our scheme
+        //  - Extract the path for discovery
+        //  - Otherwise, use the targetUri as before
+        final String serviceId = SCHEME.equals(targetUri.getScheme()) && targetUri.getHost() == null ?
+                targetUri.getPath().substring(1) :
+                targetUri.toString();
         if (serviceId.contains(":")) {
             return new NameResolver() {
                 @Override

--- a/grpc-client-runtime/src/test/groovy/io/micronaut/grpc/discovery/GrpcServiceDiscoverySpec.groovy
+++ b/grpc-client-runtime/src/test/groovy/io/micronaut/grpc/discovery/GrpcServiceDiscoverySpec.groovy
@@ -1,18 +1,3 @@
-/*
- * Copyright 2017-2019 original authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.micronaut.grpc.discovery
 
 import io.grpc.Channel
@@ -52,7 +37,6 @@ class GrpcServiceDiscoverySpec extends Specification {
         then:
         stub.sayHello(HelloRequest.newBuilder().setName("test").build()).get().message == 'Hello test'
 
-
         cleanup:
         client.stop()
         server.stop()
@@ -71,10 +55,13 @@ class GrpcServiceDiscoverySpec extends Specification {
                 'my.port':server.getPort()
         ])
 
+        and:
+        def name = "Tim"
+
         GreeterGrpc.GreeterStub stub = client.getBean(GreeterGrpc.GreeterStub)
         PollingConditions conditions = new PollingConditions(timeout: 3, delay: 0.5)
         HelloReply reply
-        stub.sayHello(HelloRequest.newBuilder().setName("test").build(), new StreamObserver<HelloReply>() {
+        stub.sayHello(HelloRequest.newBuilder().setName(name).build(), new StreamObserver<HelloReply>() {
             @Override
             void onNext(HelloReply value) {
                 reply = value
@@ -92,9 +79,8 @@ class GrpcServiceDiscoverySpec extends Specification {
         })
         then:
         conditions.eventually {
-            reply != null
+            reply.message == "Hello $name"
         }
-
 
         cleanup:
         client.stop()
@@ -113,10 +99,13 @@ class GrpcServiceDiscoverySpec extends Specification {
                 'my.port':server.getPort()
         ])
 
+        and:
+        def name = "Tim"
+
         GreeterGrpc.GreeterStub stub = client.getBean(GreeterGrpc.GreeterStub)
         PollingConditions conditions = new PollingConditions(timeout: 3, delay: 0.5)
         HelloReply reply
-        stub.sayHello(HelloRequest.newBuilder().setName("test").build(), new StreamObserver<HelloReply>() {
+        stub.sayHello(HelloRequest.newBuilder().setName(name).build(), new StreamObserver<HelloReply>() {
             @Override
             void onNext(HelloReply value) {
                 reply = value
@@ -124,24 +113,22 @@ class GrpcServiceDiscoverySpec extends Specification {
 
             @Override
             void onError(Throwable t) {
-
             }
 
             @Override
             void onCompleted() {
-
             }
         })
         then:
         conditions.eventually {
-            reply != null
+            reply.message == "Hello $name"
         }
 
 
         when:
         stub = client.getBean(GreeterGrpc.GreeterStub, Qualifiers.byName("other"))
         reply = null;
-        stub.sayHello(HelloRequest.newBuilder().setName("test").build(), new StreamObserver<HelloReply>() {
+        stub.sayHello(HelloRequest.newBuilder().setName(name).build(), new StreamObserver<HelloReply>() {
             @Override
             void onNext(HelloReply value) {
                 reply = value
@@ -149,17 +136,15 @@ class GrpcServiceDiscoverySpec extends Specification {
 
             @Override
             void onError(Throwable t) {
-
             }
 
             @Override
             void onCompleted() {
-
             }
         })
         then:
         conditions.eventually {
-            reply != null
+            reply.message == "Hello $name"
         }
 
         cleanup:

--- a/test-suite-groovy/gradle.properties
+++ b/test-suite-groovy/gradle.properties
@@ -1,2 +1,2 @@
-protobufJavaVersion=3.17.2
-grpcVersion=1.39.0
+protobufJavaVersion=3.19.4
+grpcVersion=1.45.0

--- a/test-suite-java/gradle.properties
+++ b/test-suite-java/gradle.properties
@@ -1,2 +1,2 @@
-protobufJavaVersion=3.17.2
-grpcVersion=1.39.0
+protobufJavaVersion=3.19.4
+grpcVersion=1.45.0

--- a/test-suite-kotlin/gradle.properties
+++ b/test-suite-kotlin/gradle.properties
@@ -1,5 +1,5 @@
 kotlinVersion=1.6.10
 kotlinxCoroutinesVersion=1.5.2
-protobufJavaVersion=3.17.2
-grpcVersion=1.39.0
+protobufJavaVersion=3.19.4
+grpcVersion=1.45.0
 kapt.use.worker.api=false


### PR DESCRIPTION
This is a WIP, and builds upon PR #469.

It updates protoc and grpc to latest so we get aarch_64 library support, but then
this changed service URIs to `svc:///service-name` from simply `service-name` before.

As I am a coward, this change checks that it's in svc:/// format, and falls back to
the old behaviour if it isn't.  This may not be necessary.

The entirity of the change (apart from version bumping, and test tweaks to give me a
greater sense of trust) is in the file:

io.micronaut.grpc.discovery.GrpcNameResolverProvider#newNameResolver