### PR TITLE
Update grpc in the test-suites

### DIFF
--- a/test-suite-groovy/gradle.properties
+++ b/test-suite-groovy/gradle.properties
@@ -1,2 +1,2 @@
-protobufJavaVersion=3.17.2
-grpcVersion=1.39.0
+protobufJavaVersion=3.19.4
+grpcVersion=1.45.0

--- a/test-suite-java/gradle.properties
+++ b/test-suite-java/gradle.properties
@@ -1,2 +1,2 @@
-protobufJavaVersion=3.17.2
-grpcVersion=1.39.0
+protobufJavaVersion=3.19.4
+grpcVersion=1.45.0

--- a/test-suite-kotlin/gradle.properties
+++ b/test-suite-kotlin/gradle.properties
@@ -1,5 +1,5 @@
 kotlinVersion=1.6.10
 kotlinxCoroutinesVersion=1.5.2
-protobufJavaVersion=3.17.2
-grpcVersion=1.39.0
+protobufJavaVersion=3.19.4
+grpcVersion=1.45.0
 kapt.use.worker.api=false


### PR DESCRIPTION
The test suites also define a grpc version and they are included in the docs, so we can't easily(?) switch to use the catalog