### PR TITLE
regression: Reintroduce micronaut-runtime

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ micronaut-http-server-netty = { module = 'io.micronaut:micronaut-http-server-net
 micronaut-inject-java = { module = 'io.micronaut:micronaut-inject-java' }
 micronaut-management = { module = 'io.micronaut:micronaut-management' }
 micronaut-reactor-http-client = { module = 'io.micronaut.reactor:micronaut-reactor-http-client' }
+micronaut-runtime = { module = 'io.micronaut:micronaut-runtime' }
 micronaut-tracing = { module = 'io.micronaut:micronaut-tracing' }
 micronaut-validation = { module = 'io.micronaut:micronaut-validation' }
 

--- a/grpc-client-runtime/build.gradle
+++ b/grpc-client-runtime/build.gradle
@@ -5,6 +5,7 @@ plugins {
 
 dependencies {
     api project(":grpc-annotation")
+    api libs.micronaut.runtime
     api libs.managed.grpc.protobuf
     api libs.managed.grpc.stub
 

--- a/grpc-server-runtime/build.gradle
+++ b/grpc-server-runtime/build.gradle
@@ -5,6 +5,7 @@ plugins {
 
 dependencies {
     api project(":grpc-annotation")
+    api libs.micronaut.runtime
     api libs.managed.grpc.protobuf
     api libs.managed.grpc.stub
 


### PR DESCRIPTION
As part of #469, we removed micronaut-runtime as an api dependency

This reintroduces it where it was, so it is back in the POM for the two runtime modules.

We also removed micronaut-inject as an API dependency, but this already exists in the POMs
so I am not going to add it back in as part of this

Fixes #489