### PR TITLE
Memory Leak in ByteBufToProtoMessageConverter

### DIFF
--- a/protobuff-support/src/main/java/io/micronaut/protobuf/convert/ByteBufToProtoMessageConverter.java
+++ b/protobuff-support/src/main/java/io/micronaut/protobuf/convert/ByteBufToProtoMessageConverter.java
@@ -58,8 +58,8 @@ public class ByteBufToProtoMessageConverter implements TypeConverter<ByteBuf, Me
     }
 
     private Optional<Message> rehydrate(ByteBuf object, Message.Builder builder, ConversionContext context) {
-        try {
-            builder.mergeFrom(new ByteBufInputStream(object.copy(), true), codec.getExtensionRegistry());
+        try (ByteBufInputStream byteBufInputStream = new ByteBufInputStream(object.copy(), true)) {
+            builder.mergeFrom(byteBufInputStream, codec.getExtensionRegistry());
             return Optional.of(builder.build());
         } catch (IOException e) {
             context.reject(e);


### PR DESCRIPTION

- Create the ByteBufInputStream in the resources of try-cath to force close of the resource avoiding memory leaks

https://github.com/micronaut-projects/micronaut-grpc/issues/523