### PR TITLE
Add ability to customize protobuff media type header

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,19 +1,18 @@
 # Auto detect text files and perform LF normalization
-*        text=lf
+*        text=auto
 
-*.java   text eol=lf
-*.groovy text eol=lf
-*.html   text eol=lf
-*.kt     text eol=lf
-*.kts    text eol=lf
-*.md     text diff=markdown eol=lf
+*.java   text
+*.html   text
+*.kt     text
+*.kts    text
+*.md     text diff=markdown
 *.py     text diff=python executable
 *.pl     text diff=perl executable
 *.pm     text diff=perl
-*.css    text diff=css eol=lf
-*.js     text eol=lf
-*.sql    text eol=lf
-*.q      text eol=lf
+*.css    text diff=css
+*.js     text
+*.sql    text
+*.q      text
 
 *.sh     text eol=lf
 gradlew  text eol=lf

--- a/.github/workflows/central-sync.yml
+++ b/.github/workflows/central-sync.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '11'
       - name: Publish to Sonatype OSSRH
         env:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Optional setup step
         env:

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '11'
       - name: Publish to Sonatype Snapshots
         if: success()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '11'
       - name: Set the current release version
         id: release_version

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
       - name: Optional setup step
         env:

--- a/protobuff-support/src/main/java/io/micronaut/protobuf/codec/ProtobufferCodec.java
+++ b/protobuff-support/src/main/java/io/micronaut/protobuf/codec/ProtobufferCodec.java
@@ -15,8 +15,18 @@
  */
 package io.micronaut.protobuf.codec;
 
-import com.google.protobuf.ExtensionRegistry;
-import com.google.protobuf.Message;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
 import io.micronaut.core.io.buffer.ByteBuffer;
 import io.micronaut.core.io.buffer.ByteBufferFactory;
 import io.micronaut.core.type.Argument;
@@ -25,15 +35,9 @@ import io.micronaut.http.codec.CodecException;
 import io.micronaut.http.codec.MediaTypeCodec;
 
 import jakarta.inject.Singleton;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
+
+import com.google.protobuf.ExtensionRegistry;
+import com.google.protobuf.Message;
 
 /**
  * Protocol buffers codec.
@@ -43,10 +47,7 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 @Singleton
 public class ProtobufferCodec implements MediaTypeCodec {
-    /**
-     * Protobuffer encoded data: application/x-protobuf.
-     */
-    public static final String PROTOBUFFER_ENCODED = "application/x-protobuf";
+
     /**
      * This Header is to say the fully qualified name of the message builder to use.
      * This is needed when the request is untyped
@@ -55,14 +56,32 @@ public class ProtobufferCodec implements MediaTypeCodec {
     /**
      * Protobuffer encoded data: application/x-protobuf.
      */
+    public static final String PROTOBUFFER_ENCODED = "application/x-protobuf";
+    /**
+     * Protobuffer encoded data: application/protobuf.
+     */
+    public static final String PROTOBUFFER_ENCODED2 = "application/protobuf";
+    /**
+     * Protobuffer encoded data: application/x-protobuf.
+     */
     public static final MediaType PROTOBUFFER_ENCODED_TYPE = new MediaType(PROTOBUFFER_ENCODED);
+    /**
+     * Protobuffer encoded data: application/protobuf.
+     */
+    public static final MediaType PROTOBUFFER_ENCODED_TYPE2 = new MediaType(PROTOBUFFER_ENCODED2);
+    /**
+     * List of default protobuf media types.
+     */
+    public static final List<MediaType> DEFAULT_MEDIA_TYPES = Arrays.asList(PROTOBUFFER_ENCODED_TYPE, PROTOBUFFER_ENCODED_TYPE2);
 
     private final ConcurrentHashMap<Class<?>, Method> methodCache = new ConcurrentHashMap<>();
 
     private final ExtensionRegistry extensionRegistry;
+    private List<MediaType> mediaTypes = DEFAULT_MEDIA_TYPES;
 
     /**
      * Default constructor.
+     *
      * @param extensionRegistry The extension registry
      */
     public ProtobufferCodec(ExtensionRegistry extensionRegistry) {
@@ -76,16 +95,23 @@ public class ProtobufferCodec implements MediaTypeCodec {
 
     @Override
     public Collection<MediaType> getMediaTypes() {
-        List<MediaType> mediaTypes = new ArrayList<>();
-        mediaTypes.add(PROTOBUFFER_ENCODED_TYPE);
         return mediaTypes;
+    }
+
+    /**
+     * Method to customize media types for this codec.
+     *
+     * @param mediaTypes media types for which need use this codec.
+     */
+    public void setMediaTypes(List<MediaType> mediaTypes) {
+        this.mediaTypes = Collections.unmodifiableList(new ArrayList<>(mediaTypes));
     }
 
     @Override
     public <T> T decode(Argument<T> type, InputStream inputStream) throws CodecException {
         try {
             Message.Builder builder = getBuilder(type)
-                    .orElseThrow(() -> new CodecException("Unable to create builder"));
+                .orElseThrow(() -> new CodecException("Unable to create builder"));
             if (type.hasTypeVariables()) {
                 throw new IllegalStateException("Generic type arguments are not supported");
             } else {
@@ -104,7 +130,7 @@ public class ProtobufferCodec implements MediaTypeCodec {
                 return (T) buffer.toByteArray();
             } else {
                 Message.Builder builder = getBuilder(type)
-                        .orElseThrow(() -> new CodecException("Unable to create builder"));
+                    .orElseThrow(() -> new CodecException("Unable to create builder"));
                 if (type.hasTypeVariables()) {
                     throw new IllegalStateException("Generic type arguments are not supported");
                 } else {
@@ -124,7 +150,7 @@ public class ProtobufferCodec implements MediaTypeCodec {
                 return (T) bytes;
             } else {
                 Message.Builder builder = getBuilder(type)
-                        .orElseThrow(() -> new CodecException("Unable to create builder"));
+                    .orElseThrow(() -> new CodecException("Unable to create builder"));
                 if (type.hasTypeVariables()) {
                     throw new IllegalStateException("Generic type arguments are not supported");
                 } else {
@@ -181,6 +207,7 @@ public class ProtobufferCodec implements MediaTypeCodec {
      * <p>This method uses a ConcurrentHashMap for caching method lookups.
      *
      * @param clazz The class.
+     *
      * @return The message builder
      */
     public Optional<Message.Builder> getMessageBuilder(Class<? extends Message> clazz) {
@@ -192,7 +219,7 @@ public class ProtobufferCodec implements MediaTypeCodec {
     }
 
     private Optional<Message.Builder> createBuilder(Class<? extends Message> clazz) throws Exception {
-        return Optional.of ((Message.Builder) getMethod(clazz).invoke(clazz));
+        return Optional.of((Message.Builder) getMethod(clazz).invoke(clazz));
     }
 
     private Method getMethod(Class<? extends Message> clazz) throws NoSuchMethodException {

--- a/protobuff-support/src/test/groovy/io/micronaut/ProgramaticController.groovy
+++ b/protobuff-support/src/test/groovy/io/micronaut/ProgramaticController.groovy
@@ -29,7 +29,7 @@ class ProgramaticController {
             .setLng(-6.266155D)
             .build()
 
-    @Get(processes = ProtobufferCodec.PROTOBUFFER_ENCODED)
+    @Get(processes = [ProtobufferCodec.PROTOBUFFER_ENCODED, ProtobufferCodec.PROTOBUFFER_ENCODED2, "my/myAppType"])
     Example.GeoPoint city() {
         DUBLIN
     }

--- a/protobuff-support/src/test/groovy/io/micronaut/ProgramaticControllerSpec.groovy
+++ b/protobuff-support/src/test/groovy/io/micronaut/ProgramaticControllerSpec.groovy
@@ -16,17 +16,36 @@
 package io.micronaut
 
 import com.example.wire.Example
+import io.micronaut.protobuf.codec.ProtobufferCodec
 
 class ProgramaticControllerSpec extends BaseSpec {
 
     String url = embeddedServer.getURL().toString() + '/town'
 
     void "sample city should be dublin/using programmatic controller controller"() {
-        when:'The message is requested from the sever=[#url]'
-            def response = getMessage(url, Example.GeoPoint.class)
-        and:'The message is parser'
-            Example.GeoPoint city  = Example.GeoPoint.parseFrom(response)
-        then:'Should be Dublin'
-            SampleController.DUBLIN == city
+        when: 'The message is requested from the sever=[#url]'
+        def response = getMessage(url, Example.GeoPoint.class, ProtobufferCodec.PROTOBUFFER_ENCODED)
+        and: 'The message is parser'
+        Example.GeoPoint city = Example.GeoPoint.parseFrom(response)
+        then: 'Should be Dublin'
+        SampleController.DUBLIN == city
+    }
+
+    void "sample city should be dublin/using programmatic controller controller with second codec header"() {
+        when: 'The message is requested from the sever=[#url]'
+        def response = getMessage(url, Example.GeoPoint.class, ProtobufferCodec.PROTOBUFFER_ENCODED2)
+        and: 'The message is parser'
+        Example.GeoPoint city = Example.GeoPoint.parseFrom(response)
+        then: 'Should be Dublin'
+        SampleController.DUBLIN == city
+    }
+
+    void "sample city should be dublin/using programmatic controller controller with custom codec header"() {
+        when: 'The message is requested from the sever=[#url]'
+        def response = getMessage(url, Example.GeoPoint.class, SampleController.MY_PROTO_ENCODED)
+        and: 'The message is parser'
+        Example.GeoPoint city = Example.GeoPoint.parseFrom(response)
+        then: 'Should be Dublin'
+        SampleController.DUBLIN == city
     }
 }

--- a/protobuff-support/src/test/groovy/io/micronaut/SampleController.groovy
+++ b/protobuff-support/src/test/groovy/io/micronaut/SampleController.groovy
@@ -17,6 +17,7 @@ package io.micronaut
 
 import com.example.wire.Example
 import groovy.transform.CompileStatic
+import io.micronaut.http.MediaType
 import io.micronaut.http.annotation.Body
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
@@ -26,17 +27,21 @@ import io.micronaut.protobuf.codec.ProtobufferCodec
 @Controller
 @CompileStatic
 class SampleController {
+
+    public static final String MY_PROTO_ENCODED = "my/myAppType"
+    public static final MediaType MY_PROTO_ENCODED_TYPE = new MediaType(MY_PROTO_ENCODED)
+
     public static Example.GeoPoint DUBLIN = Example.GeoPoint.newBuilder()
             .setLat(53.350140D)
             .setLng(-6.266155D)
             .build()
 
-    @Get(value = "/city", processes = ProtobufferCodec.PROTOBUFFER_ENCODED)
+    @Get(value = "/city", processes = [ProtobufferCodec.PROTOBUFFER_ENCODED, ProtobufferCodec.PROTOBUFFER_ENCODED2, "my/myAppType"])
     Example.GeoPoint city() {
         DUBLIN
     }
 
-    @Post(value = "/nearby", processes = ProtobufferCodec.PROTOBUFFER_ENCODED)
+    @Post(value = "/nearby", processes = [ProtobufferCodec.PROTOBUFFER_ENCODED, ProtobufferCodec.PROTOBUFFER_ENCODED2, "my/myAppType"])
     Example.GeoPoint suggestVisitNearBy(@Body Example.GeoPoint point) {
         DUBLIN
     }

--- a/protobuff-support/src/test/groovy/io/micronaut/SimpleHttpGetSpec.groovy
+++ b/protobuff-support/src/test/groovy/io/micronaut/SimpleHttpGetSpec.groovy
@@ -16,17 +16,36 @@
 package io.micronaut
 
 import com.example.wire.Example
+import io.micronaut.protobuf.codec.ProtobufferCodec
 
 class SimpleHttpGetSpec extends BaseSpec {
 
     String url = embeddedServer.getURL().toString() + '/city'
 
     void "sample city should be dublin/using sample controller"() {
-        when:'The message is requested from the sever=[#url]'
-            def response = getMessage(url, Example.GeoPoint.class)
-        and:'The message is parser'
-            Example.GeoPoint city  = Example.GeoPoint.parseFrom(response)
-        then:'Should be Dublin'
-            SampleController.DUBLIN == city
+        when: 'The message is requested from the sever=[#url]'
+        def response = getMessage(url, Example.GeoPoint.class, ProtobufferCodec.PROTOBUFFER_ENCODED)
+        and: 'The message is parser'
+        Example.GeoPoint city = Example.GeoPoint.parseFrom(response)
+        then: 'Should be Dublin'
+        SampleController.DUBLIN == city
+    }
+
+    void "test second protobuff content type header"() {
+        when: 'The message is requested from the sever=[#url]'
+        def response = getMessage(url, Example.GeoPoint.class, ProtobufferCodec.PROTOBUFFER_ENCODED2)
+        and: 'The message is parser'
+        Example.GeoPoint city = Example.GeoPoint.parseFrom(response)
+        then: 'Should be Dublin'
+        SampleController.DUBLIN == city
+    }
+
+    void "test cutom protobuff content type header"() {
+        when: 'The message is requested from the sever=[#url]'
+        def response = getMessage(url, Example.GeoPoint.class, SampleController.MY_PROTO_ENCODED)
+        and: 'The message is parser'
+        Example.GeoPoint city = Example.GeoPoint.parseFrom(response)
+        then: 'Should be Dublin'
+        SampleController.DUBLIN == city
     }
 }

--- a/protobuff-support/src/test/groovy/io/micronaut/SimpleHttpPostSpec.groovy
+++ b/protobuff-support/src/test/groovy/io/micronaut/SimpleHttpPostSpec.groovy
@@ -16,6 +16,7 @@
 package io.micronaut
 
 import com.example.wire.Example
+import io.micronaut.protobuf.codec.ProtobufferCodec
 
 class SimpleHttpPostSpec extends BaseSpec {
 
@@ -23,17 +24,49 @@ class SimpleHttpPostSpec extends BaseSpec {
 
     void "near by Dublin should be Dublin"() {
         setup:
-            Example.GeoPoint message = SampleController.DUBLIN
-        when:'The message is posted to the server=[#url]'
-            def response = postMessage(url, message)
-        and:'The message is parsed'
-            Example.GeoPoint city = Example.GeoPoint.parseFrom(response)
-        then:'Should be Dublin'
-            SampleController.DUBLIN == city
+        Example.GeoPoint message = SampleController.DUBLIN
+        when: 'The message is posted to the server=[#url]'
+        def response = postMessage(url, message, ProtobufferCodec.PROTOBUFFER_ENCODED)
+        and: 'The message is parsed'
+        Example.GeoPoint city = Example.GeoPoint.parseFrom(response)
+        then: 'Should be Dublin'
+        SampleController.DUBLIN == city
 
-        when:'The byte[] is posted to the server=[#url]'
-            response = postMessage(url, message.toByteArray())
-        then:'The message is parsed'
-            Example.GeoPoint.parseFrom(response) == SampleController.DUBLIN
+        when: 'The byte[] is posted to the server=[#url]'
+        response = postMessage(url, message.toByteArray(), ProtobufferCodec.PROTOBUFFER_ENCODED)
+        then: 'The message is parsed'
+        Example.GeoPoint.parseFrom(response) == SampleController.DUBLIN
+    }
+
+    void "test second protobuff content type header"() {
+        setup:
+        Example.GeoPoint message = SampleController.DUBLIN
+        when: 'The message is posted to the server=[#url]'
+        def response = postMessage(url, message, ProtobufferCodec.PROTOBUFFER_ENCODED2)
+        and: 'The message is parsed'
+        Example.GeoPoint city = Example.GeoPoint.parseFrom(response)
+        then: 'Should be Dublin'
+        SampleController.DUBLIN == city
+
+        when: 'The byte[] is posted to the server=[#url]'
+        response = postMessage(url, message.toByteArray(), ProtobufferCodec.PROTOBUFFER_ENCODED2)
+        then: 'The message is parsed'
+        Example.GeoPoint.parseFrom(response) == SampleController.DUBLIN
+    }
+
+    void "test custom protobuff content type header"() {
+        setup:
+        Example.GeoPoint message = SampleController.DUBLIN
+        when: 'The message is posted to the server=[#url]'
+        def response = postMessage(url, message, SampleController.MY_PROTO_ENCODED)
+        and: 'The message is parsed'
+        Example.GeoPoint city = Example.GeoPoint.parseFrom(response)
+        then: 'Should be Dublin'
+        SampleController.DUBLIN == city
+
+        when: 'The byte[] is posted to the server=[#url]'
+        response = postMessage(url, message.toByteArray(), SampleController.MY_PROTO_ENCODED)
+        then: 'The message is parsed'
+        Example.GeoPoint.parseFrom(response) == SampleController.DUBLIN
     }
 }


### PR DESCRIPTION
Sometimes I don't want to give anyone information about my API format and use a custom content-type/accept header value for it. Now you can replace the default ProtobufferCodec and set any media types you want.

I also added a second default media type value, application/protobuf, because it is used by other libraries such as guava.

This is rebased PR (copy of https://github.com/micronaut-projects/micronaut-grpc/pull/601), but from master branch