### PR TITLE
Fix missing ResourceResolver for gRPC server

### DIFF
--- a/grpc-server-runtime/src/main/java/io/micronaut/grpc/server/GrpcResourceLoaderFactory.java
+++ b/grpc-server-runtime/src/main/java/io/micronaut/grpc/server/GrpcResourceLoaderFactory.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.grpc.server;
+
+import java.util.List;
+
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.env.Environment;
+import io.micronaut.core.io.ResourceLoader;
+import io.micronaut.core.io.ResourceResolver;
+import io.micronaut.core.io.file.FileSystemResourceLoader;
+import io.micronaut.core.io.scan.ClassPathResourceLoader;
+import io.micronaut.core.io.value.Base64ResourceLoader;
+import io.micronaut.core.io.value.StringResourceLoader;
+
+import jakarta.inject.Singleton;
+
+/**
+ * Provides core resource loading support when the HTTP module is not present.
+ *
+ * @since 5.0.0
+ */
+@Factory
+public class GrpcResourceLoaderFactory {
+
+    private final ClassLoader classLoader;
+
+    /**
+     * @param environment The environment
+     */
+    public GrpcResourceLoaderFactory(Environment environment) {
+        this.classLoader = environment.getClassLoader();
+    }
+
+    /**
+     * @return The classpath resource loader
+     */
+    @Singleton
+    @Requires(missingBeans = ClassPathResourceLoader.class)
+    protected ClassPathResourceLoader getClassPathResourceLoader() {
+        return ClassPathResourceLoader.defaultLoader(classLoader);
+    }
+
+    /**
+     * @return The filesystem resource loader
+     */
+    @Singleton
+    @Requires(missingBeans = FileSystemResourceLoader.class)
+    protected FileSystemResourceLoader fileSystemResourceLoader() {
+        return FileSystemResourceLoader.defaultLoader();
+    }
+
+    /**
+     * @return The string resource loader
+     */
+    @Singleton
+    @Requires(missingBeans = StringResourceLoader.class)
+    protected StringResourceLoader getStringResourceLoader() {
+        return (StringResourceLoader) StringResourceLoader.getInstance();
+    }
+
+    /**
+     * @return The base64 resource loader
+     */
+    @Singleton
+    @Requires(missingBeans = Base64ResourceLoader.class)
+    protected Base64ResourceLoader getBase64ResourceLoader() {
+        return (Base64ResourceLoader) Base64ResourceLoader.getInstance();
+    }
+
+    /**
+     * @param resourceLoaders The resource loaders
+     * @return The resource resolver
+     */
+    @Singleton
+    @Requires(missingBeans = ResourceResolver.class)
+    protected ResourceResolver resourceResolver(List<ResourceLoader> resourceLoaders) {
+        return new ResourceResolver(resourceLoaders);
+    }
+}

--- a/grpc-server-runtime/src/test/groovy/io/micronaut/grpc/GrpcServerConfigurationSpec.groovy
+++ b/grpc-server-runtime/src/test/groovy/io/micronaut/grpc/GrpcServerConfigurationSpec.groovy
@@ -17,6 +17,8 @@ package io.micronaut.grpc
 
 import io.grpc.ServerBuilder
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.env.Environment
+import io.micronaut.core.io.ResourceResolver
 import io.micronaut.core.io.socket.SocketUtils
 import io.micronaut.grpc.server.GrpcServerConfiguration
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
@@ -70,5 +72,49 @@ class GrpcServerConfigurationSpec extends Specification {
         cleanup:
         server.shutdown().awaitTermination()
         ctx.close()
+    }
+
+    void "test GRPC server provides resource resolver without micronaut http resource factory"() {
+        given:
+        def port = SocketUtils.findAvailableTcpPort()
+        def ctx = ApplicationContext.builder(new DenyingClassLoader(getClass().classLoader, 'io.micronaut.http.resource.'))
+                .environments(Environment.TEST)
+                .properties([
+                        'grpc.server.port'           : port,
+                        'grpc.server.ssl.cert-chain' : 'classpath:example.crt',
+                        'grpc.server.ssl.private-key': 'classpath:example.key',
+                ])
+                .start()
+
+        when:
+        ResourceResolver resourceResolver = ctx.getBean(ResourceResolver)
+        GrpcServerConfiguration configuration = ctx.getBean(GrpcServerConfiguration)
+        def server = configuration.getServerBuilder().build()
+        server.start()
+
+        then:
+        resourceResolver.getResourceAsStream('classpath:example.crt').present
+        configuration.secure
+
+        cleanup:
+        server.shutdown().awaitTermination()
+        ctx.close()
+    }
+
+    private static final class DenyingClassLoader extends ClassLoader {
+        private final List<String> deniedPrefixes
+
+        DenyingClassLoader(ClassLoader parent, String... deniedPrefixes) {
+            super(parent)
+            this.deniedPrefixes = deniedPrefixes.toList()
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (deniedPrefixes.any { name.startsWith(it) }) {
+                throw new ClassNotFoundException(name)
+            }
+            return super.loadClass(name, resolve)
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Provide core resource loader beans in the gRPC server runtime when the HTTP resource factory is absent
- Add a regression test that starts the gRPC server with the HTTP resource package hidden and verifies SSL resource resolution

## Verification

- `./gradlew :micronaut-grpc-server-runtime:test --tests io.micronaut.grpc.GrpcServerConfigurationSpec`

Resolves https://github.com/micronaut-projects/micronaut-grpc/issues/1112
