### PR TITLE
Add Kotest variant for GreetingServiceTest

### DIFF
--- a/src/main/docs/guide/server.adoc
+++ b/src/main/docs/guide/server.adoc
@@ -148,7 +148,7 @@ If you wish to disable the Micronaut gRPC server health check while still using 
 
 To test the server it is recommended that you use https://github.com/micronaut-projects/micronaut-test[Micronaut Test].
 
-TIP: For detailed instructions on how to set up Micronaut Test for either Spock or JUnit 5 see the https://micronaut-projects.github.io/micronaut-test/latest/guide/index.html[documentation] on the subject.
+TIP: For detailed instructions on how to set up Micronaut Test for Spock, JUnit 5, or Kotest see the https://micronaut-projects.github.io/micronaut-test/latest/guide/index.html[documentation] on the subject.
 
 
 You can then define a blocking stub bean in `src/test/java`. For example:

--- a/test-suite-kotlin/build.gradle
+++ b/test-suite-kotlin/build.gradle
@@ -50,6 +50,7 @@ dependencies {
     runtimeOnly mn.jackson.module.kotlin
 
     testCompileOnly libs.javax.annotation.api
+    testImplementation mnTest.micronaut.test.kotest5
 
     testRuntimeOnly mnLogging.logback.classic
     testRuntimeOnly mn.jackson.module.kotlin

--- a/test-suite-kotlin/src/test/kotlin/helloworld/GreetingServiceFactory.kt
+++ b/test-suite-kotlin/src/test/kotlin/helloworld/GreetingServiceFactory.kt
@@ -15,17 +15,16 @@
  */
 package helloworld
 
-import io.kotest.core.spec.style.StringSpec
-import io.kotest.matchers.shouldBe
-import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
+import io.grpc.ManagedChannel
+import io.micronaut.context.annotation.Factory
+import io.micronaut.grpc.annotation.GrpcChannel
+import io.micronaut.grpc.server.GrpcServerChannel
+import jakarta.inject.Singleton
 
-@MicronautTest
-class GreetingServiceTest(
-    private val greetingClient: GreeterGrpcKt.GreeterCoroutineStub,
-) : StringSpec({
-    "returns a greeting response" {
-        greetingClient.sayHello(
-            HelloRequest.newBuilder().setName("John").build(),
-        ).message shouldBe "Hello John"
-    }
-})
+@Factory
+class GreetingServiceFactory {
+
+    @Singleton
+    fun greetingClient(@GrpcChannel(GrpcServerChannel.NAME) channel: ManagedChannel): GreeterGrpcKt.GreeterCoroutineStub =
+        GreeterGrpcKt.GreeterCoroutineStub(channel)
+}

--- a/test-suite-kotlin/src/test/kotlin/helloworld/ProjectConfig.kt
+++ b/test-suite-kotlin/src/test/kotlin/helloworld/ProjectConfig.kt
@@ -15,17 +15,11 @@
  */
 package helloworld
 
-import io.kotest.core.spec.style.StringSpec
-import io.kotest.matchers.shouldBe
-import io.micronaut.test.extensions.kotest5.annotation.MicronautTest
+import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.extensions.Extension
+import io.micronaut.test.extensions.kotest5.MicronautKotest5Extension
 
-@MicronautTest
-class GreetingServiceTest(
-    private val greetingClient: GreeterGrpcKt.GreeterCoroutineStub,
-) : StringSpec({
-    "returns a greeting response" {
-        greetingClient.sayHello(
-            HelloRequest.newBuilder().setName("John").build(),
-        ).message shouldBe "Hello John"
-    }
-})
+class ProjectConfig : AbstractProjectConfig() {
+
+    override val extensions: List<Extension> = listOf(MicronautKotest5Extension)
+}


### PR DESCRIPTION
## Summary
- add a Kotest version of the Kotlin `GreetingServiceTest` example
- move the greeting client test bean into its own factory and register the Micronaut Kotest extension with a Kotest `ProjectConfig`
- mention Kotest alongside the existing Micronaut Test options in the gRPC server testing guide

## Verification
- `./gradlew :test-suite-kotlin:test --tests 'helloworld.GreetingServiceTest'`
- `./gradlew :test-suite-kotlin:test`

Resolves #246
