### PR TITLE
docs: fix gRPC setup guide examples

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,3 +11,33 @@ configurations.all {
         preferProjectModules()
     }
 }
+
+def guideVersionAttributes = layout.buildDirectory.file("generated/docs/guide-version-attributes.adoc")
+
+tasks.register("generateGuideVersionAttributes") {
+    outputs.file(guideVersionAttributes)
+    doLast {
+        def versionCatalog = file("gradle/libs.versions.toml").text
+        def findVersion = { String key ->
+            def matcher = versionCatalog =~ /(?m)^${java.util.regex.Pattern.quote(key)}\s*=\s*['"]([^'"]+)['"]\s*$/
+            if (!matcher.find()) {
+                throw new GradleException("Unable to find version '${key}' in gradle/libs.versions.toml")
+            }
+            matcher.group(1)
+        }
+        def attrs = [
+            "grpc-version"                   : findVersion("managed-grpc"),
+            "grpc-kotlin-version"            : findVersion("managed-grpc-kotlin"),
+            "protobuf-version"               : findVersion("managed-protobuf"),
+            "protobuf-gradle-plugin-version" : findVersion("managed-protobuf-gradle"),
+            "javax-annotation-api-version"   : findVersion("javax-annotation-api"),
+        ]
+        def output = guideVersionAttributes.get().asFile
+        output.parentFile.mkdirs()
+        output.text = attrs.collect { key, value -> ":${key}: ${value}" }.join(System.lineSeparator()) + System.lineSeparator()
+    }
+}
+
+tasks.matching { it.name in ["publishGuide", "docs"] }.configureEach {
+    dependsOn(tasks.named("generateGuideVersionAttributes"))
+}

--- a/src/main/docs/guide/gettingStarted.adoc
+++ b/src/main/docs/guide/gettingStarted.adoc
@@ -1,3 +1,5 @@
+include::build/generated/docs/guide-version-attributes.adoc[]
+
 To get started you need first create a Micronaut project. The easiest way to do this is with the Micronaut Launch:
 
 * Go to https://micronaut.io/launch/[Micronaut Launch]
@@ -28,51 +30,46 @@ Then follow the below steps depending on the build system chosen.
 
 === Configuring Gradle
 
-To configure Gradle, first apply the `com.google.protobuf` plugin:
+To configure Gradle for Java or Groovy projects, add the `com.google.protobuf` plugin to your existing `plugins` block:
 
-[source,groovy]
+[source,groovy,subs="attributes+"]
 ----
 plugins {
     ...
-include::test-suite-java/build.gradle[tags=plugin]
+include::src/main/docs/guide/snippets/gradle-java-setup.gradle[tags=plugin]
+}
+----
+
+Then configure protobuf source generation:
+
+[source,groovy,subs="attributes+"]
+----
+include::src/main/docs/guide/snippets/gradle-java-setup.gradle[tags=config]
+----
+NOTE: If you are using JDK 9 or above, provide the following compiler option to the gRPC plugin to skip `javax.annotation.Generated` stubs: `option '@generated=omit'` (added in link:https://github.com/grpc/grpc-java/releases/tag/v1.64.0[gRPC Java v1.64.0]). See link:https://github.com/grpc/grpc-java/issues/9179[issue 9179] for background.
+
+[source,groovy,subs="attributes+"]
+----
+include::src/main/docs/guide/snippets/gradle-java-setup.gradle[tags=omit-generated]
+----
+
+Use this Gradle configuration for Kotlin projects:
+
+[source,groovy,subs="attributes+"]
+----
+plugins {
+    ...
+include::src/main/docs/guide/snippets/gradle-kotlin-setup.gradle[tags=plugin]
 }
 
-----
-
-Then configure the gRPC and protobuf plugins:
-
-[source,groovy]
-----
-include::test-suite-java/build.gradle[tags=variables]
-
-include::test-suite-java/build.gradle[tags=config]
-----
-NOTE: If you are using JDK9 or above, in order to avoid issues javax packages, provide the following compiler option to the grpc plugin to skip these stubs: `option '@generated=omit'` (added on link:https://github.com/grpc/grpc-java/releases/tag/v1.64.0[grpc-kava v1.64.0]) See discussion here: link:https://github.com/grpc/grpc-java/issues/9179[issue 9179]
-
-[source,groovy]
-----
-    ...
-    generateProtoTasks {
-        all()*.plugins {
-            grpc {
-                option '@generated=omit'
-            } }
-    }
-----
-
-Use this configuration for Kotlin projects:
-
-[source,groovy]
-----
-include::test-suite-kotlin/build.gradle[tags=variables]
+include::src/main/docs/guide/snippets/gradle-kotlin-setup.gradle[tags=variables]
 
 dependencies {
-...
-include::test-suite-kotlin/build.gradle[tags=dependencies]
+    ...
+include::src/main/docs/guide/snippets/gradle-kotlin-setup.gradle[tags=dependencies]
 }
 
-include::test-suite-kotlin/build.gradle[tags=config]
-
+include::src/main/docs/guide/snippets/gradle-kotlin-setup.gradle[tags=config]
 ----
 
 If you want to generate Reactor-based stubs with https://github.com/salesforce/reactive-grpc[reactive-grpc], add the generator plugin and stub dependency alongside the standard gRPC code generation:
@@ -117,9 +114,13 @@ NOTE: If you wish to use gRPC standalone without the Micronaut HTTP server you s
 You can then run:
 
 [source,bash]
+----
 $ ./gradlew generateProto
+----
 
 To generate the Java sources from protobuf definitions in `src/main/proto`.
+
+The generated sources are the service stubs, not the server implementation. Before starting the application, create a bean that extends the generated `*ImplBase` type (or `*CoroutineImplBase` for Kotlin) as shown in the next section.
 
 === Configuring Maven
 
@@ -140,7 +141,9 @@ include::test-suite-java/pom.xml[tags=plugin, indent=0]
 You can then run:
 
 [source,bash]
+----
 $ ./mvnw generate-sources
+----
 
 To generate the Java sources from protobuf definitions in `src/main/proto`.
 

--- a/src/main/docs/guide/snippets/gradle-java-setup.gradle
+++ b/src/main/docs/guide/snippets/gradle-java-setup.gradle
@@ -1,0 +1,40 @@
+plugins {
+    ...
+    // tag::plugin[]
+    id 'com.google.protobuf' version '{protobuf-gradle-plugin-version}'
+    // end::plugin[]
+}
+
+// tag::config[]
+def grpcVersion = '{grpc-version}'
+def protobufVersion = '{protobuf-version}'
+
+sourceSets {
+    main {
+        java {
+            srcDirs 'build/generated/source/proto/main/grpc'
+            srcDirs 'build/generated/source/proto/main/java'
+        }
+    }
+}
+
+protobuf {
+    protoc { artifact = "com.google.protobuf:protoc:$protobufVersion" }
+    plugins {
+        grpc { artifact = "io.grpc:protoc-gen-grpc-java:$grpcVersion" }
+    }
+    generateProtoTasks {
+        all()*.plugins { grpc {} }
+    }
+}
+// end::config[]
+
+// tag::omit-generated[]
+generateProtoTasks {
+    all()*.plugins {
+        grpc {
+            option '@generated=omit'
+        }
+    }
+}
+// end::omit-generated[]

--- a/src/main/docs/guide/snippets/gradle-kotlin-setup.gradle
+++ b/src/main/docs/guide/snippets/gradle-kotlin-setup.gradle
@@ -1,0 +1,48 @@
+plugins {
+    ...
+    // tag::plugin[]
+    id 'com.google.protobuf' version '{protobuf-gradle-plugin-version}'
+    // end::plugin[]
+}
+
+// tag::variables[]
+def grpcVersion = '{grpc-version}'
+def grpcKotlinVersion = '{grpc-kotlin-version}'
+def protobufVersion = '{protobuf-version}'
+// end::variables[]
+
+dependencies {
+    // tag::dependencies[]
+    implementation("io.grpc:grpc-kotlin-stub:$grpcKotlinVersion")
+    implementation("io.grpc:grpc-services:$grpcVersion")
+    compileOnly("io.grpc:grpc-stub:$grpcVersion")
+    compileOnly("com.google.protobuf:protobuf-java:$protobufVersion")
+    compileOnly("javax.annotation:javax.annotation-api:{javax-annotation-api-version}")
+    // end::dependencies[]
+}
+
+// tag::config[]
+sourceSets {
+    main {
+        java {
+            srcDirs 'build/generated/source/proto/main/grpc'
+            srcDirs 'build/generated/source/proto/main/grpckt'
+            srcDirs 'build/generated/source/proto/main/java'
+        }
+    }
+}
+
+protobuf {
+    protoc { artifact = "com.google.protobuf:protoc:$protobufVersion" }
+    plugins {
+        grpc { artifact = "io.grpc:protoc-gen-grpc-java:$grpcVersion" }
+        grpckt { artifact = "io.grpc:protoc-gen-grpc-kotlin:$grpcKotlinVersion:jdk8@jar" }
+    }
+    generateProtoTasks {
+        all()*.plugins {
+            grpc {}
+            grpckt {}
+        }
+    }
+}
+// end::config[]


### PR DESCRIPTION
## Summary
- replace the getting started Gradle examples with include-backed snippet files that show copy-pasteable user project configuration
- keep the documented setup aligned with `gradle/libs.versions.toml` by generating AsciiDoc attributes for the current protobuf and gRPC versions during the docs build
- clarify that generated proto sources provide service stubs and the application still needs a service implementation bean

## Verification
- ./gradlew docs

Resolves #964
