### PR TITLE
Add reactive gRPC example and docs

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ opentracing-mock = '0.33.0'
 graal-svm = '25.0.3'
 javax-annotation-api = '1.3.2'
 gson = "2.13.2"
+reactive-grpc = "1.2.4"
 
 micronaut-gradle-plugin = '4.6.2'
 micronaut-tracing-legacy = '3.2.7'
@@ -57,6 +58,7 @@ micronaut-serde-jackson = { module = 'io.micronaut.serde:micronaut-serde-jackson
 
 # Other
 gson = { module = 'com.google.code.gson:gson', version.ref = 'gson' }
+reactive-grpc-stub = { module = 'com.salesforce.servicelibs:reactor-grpc-stub', version.ref = 'reactive-grpc' }
 graal-svm = { module = 'org.graalvm.nativeimage:svm', version.ref = 'graal-svm' }
 grpc-netty = { module = 'io.grpc:grpc-netty' }
 

--- a/src/main/docs/guide/client.adoc
+++ b/src/main/docs/guide/client.adoc
@@ -85,3 +85,17 @@ GreeterGrpc.GreeterStub reactiveStub(
 The ID `greeter` is used to reference the configuration for `grpc.channels.greeter`.
 
 Using service IDs in this way is the preferred way to set up gRPC clients, because it works nicely with Service Discovery (see the next section).
+
+If you generate Reactor bindings with `reactive-grpc`, define the generated Reactor stub in the same kind of factory and inject the `ManagedChannel` with `@GrpcChannel`:
+
+[source,java]
+----
+include::test-suite-java/src/test/java/helloworld/ReactiveGreetingEndpointTest.java[tags=reactive-client]
+----
+
+The resulting stub can then be injected into your application or tests and used directly with Reactor operators:
+
+[source,java]
+----
+include::test-suite-java/src/test/java/helloworld/ReactiveGreetingEndpointTest.java[tags=reactive-test]
+----

--- a/src/main/docs/guide/gettingStarted.adoc
+++ b/src/main/docs/guide/gettingStarted.adoc
@@ -86,7 +86,13 @@ dependencies {
 include::test-suite-java/build.gradle[tags=reactive-dependencies]
 }
 
+sourceSets {
+    main {
+        java {
 include::test-suite-java/build.gradle[tags=reactive-source-set]
+        }
+    }
+}
 
 protobuf {
 ...

--- a/src/main/docs/guide/gettingStarted.adoc
+++ b/src/main/docs/guide/gettingStarted.adoc
@@ -43,6 +43,8 @@ Then configure the gRPC and protobuf plugins:
 
 [source,groovy]
 ----
+include::test-suite-java/build.gradle[tags=variables]
+
 include::test-suite-java/build.gradle[tags=config]
 ----
 NOTE: If you are using JDK9 or above, in order to avoid issues javax packages, provide the following compiler option to the grpc plugin to skip these stubs: `option '@generated=omit'` (added on link:https://github.com/grpc/grpc-java/releases/tag/v1.64.0[grpc-kava v1.64.0]) See discussion here: link:https://github.com/grpc/grpc-java/issues/9179[issue 9179]
@@ -71,6 +73,27 @@ include::test-suite-kotlin/build.gradle[tags=dependencies]
 
 include::test-suite-kotlin/build.gradle[tags=config]
 
+----
+
+If you want to generate Reactor-based stubs with https://github.com/salesforce/reactive-grpc[reactive-grpc], add the generator plugin and stub dependency alongside the standard gRPC code generation:
+
+[source,groovy]
+----
+include::test-suite-java/build.gradle[tags=reactive-variables]
+
+dependencies {
+...
+include::test-suite-java/build.gradle[tags=reactive-dependencies]
+}
+
+include::test-suite-java/build.gradle[tags=reactive-source-set]
+
+protobuf {
+...
+include::test-suite-java/build.gradle[tags=reactive-plugin]
+...
+include::test-suite-java/build.gradle[tags=reactive-config]
+}
 ----
 
 Finally, add the following dependencies to your build:

--- a/src/main/docs/guide/server.adoc
+++ b/src/main/docs/guide/server.adoc
@@ -10,6 +10,13 @@ snippet::helloworld.GreetingEndpoint[tags="imports,clazz", source="main"]
 <2> You can dependency inject other beans into the implementation. In this case `GreetingService` is dependency injected.
 <3> The `StreamObserver` is used to send a response to the client.
 
+If you generate Reactor bindings with `reactive-grpc`, Micronaut can register the generated `BindableService` implementation in exactly the same way. Implement the generated Reactor base class as a singleton bean:
+
+[source,java]
+----
+include::test-suite-java/src/main/java/helloworld/ReactiveGreetingEndpoint.java[tags=reactive-service]
+----
+
 === Running the gRPC Server
 
 To run the server use the `Application` class or run `./gradlew run` for Gradle or `./mvnw compile exec:exec` for Maven.

--- a/test-suite-java/build.gradle
+++ b/test-suite-java/build.gradle
@@ -13,6 +13,12 @@ ext {
 }
 // end::variables[]
 
+// tag::reactive-variables[]
+ext {
+    reactiveGrpcVersion = libs.versions.reactive.grpc.get()
+}
+// end::reactive-variables[]
+
 application {
     mainClass = "helloworld.Application"
 }
@@ -41,6 +47,11 @@ dependencies {
     implementation projects.micronautGrpcServerRuntime
     implementation libs.micronaut.discovery.client
     implementation libs.managed.grpc.services
+    // tag::reactive-dependencies[]
+    implementation platform(libs.micronaut.reactor)
+    implementation libs.reactive.grpc.stub
+    implementation "io.projectreactor:reactor-core"
+    // end::reactive-dependencies[]
     implementation mn.snakeyaml
 
     runtimeOnly mnLogging.logback.classic
@@ -66,14 +77,46 @@ sourceSets {
         }
     }
 }
+// end::config[]
 
+// tag::reactive-source-set[]
+sourceSets {
+    main {
+        java {
+            srcDirs 'build/generated/source/proto/main/reactor'
+        }
+    }
+}
+// end::reactive-source-set[]
+
+// tag::config[]
 protobuf {
     protoc { artifact = "com.google.protobuf:protoc:$protobufVersion" }
     plugins {
         grpc { artifact = "io.grpc:protoc-gen-grpc-java:$grpcVersion" }
     }
     generateProtoTasks {
-        all()*.plugins { grpc {} }
+        all()*.plugins {
+            grpc {}
+        }
     }
 }
 // end::config[]
+
+// tag::reactive-plugin[]
+protobuf {
+    plugins {
+        reactor { artifact = "com.salesforce.servicelibs:reactor-grpc:$reactiveGrpcVersion" }
+    }
+}
+// end::reactive-plugin[]
+
+// tag::reactive-config[]
+protobuf {
+    generateProtoTasks {
+        all()*.plugins {
+            reactor {}
+        }
+    }
+}
+// end::reactive-config[]

--- a/test-suite-java/build.gradle
+++ b/test-suite-java/build.gradle
@@ -74,49 +74,36 @@ sourceSets {
         java {
             srcDirs 'build/generated/source/proto/main/grpc'
             srcDirs 'build/generated/source/proto/main/java'
+// end::config[]
+// tag::reactive-source-set[]
+            srcDirs 'build/generated/source/proto/main/reactor'
+// end::reactive-source-set[]
+// tag::config[]
         }
     }
 }
 // end::config[]
-
-// tag::reactive-source-set[]
-sourceSets {
-    main {
-        java {
-            srcDirs 'build/generated/source/proto/main/reactor'
-        }
-    }
-}
-// end::reactive-source-set[]
 
 // tag::config[]
 protobuf {
     protoc { artifact = "com.google.protobuf:protoc:$protobufVersion" }
     plugins {
         grpc { artifact = "io.grpc:protoc-gen-grpc-java:$grpcVersion" }
+// end::config[]
+// tag::reactive-plugin[]
+        reactor { artifact = "com.salesforce.servicelibs:reactor-grpc:$reactiveGrpcVersion" }
+// end::reactive-plugin[]
+// tag::config[]
     }
     generateProtoTasks {
         all()*.plugins {
             grpc {}
+// end::config[]
+// tag::reactive-config[]
+            reactor {}
+// end::reactive-config[]
+// tag::config[]
         }
     }
 }
 // end::config[]
-
-// tag::reactive-plugin[]
-protobuf {
-    plugins {
-        reactor { artifact = "com.salesforce.servicelibs:reactor-grpc:$reactiveGrpcVersion" }
-    }
-}
-// end::reactive-plugin[]
-
-// tag::reactive-config[]
-protobuf {
-    generateProtoTasks {
-        all()*.plugins {
-            reactor {}
-        }
-    }
-}
-// end::reactive-config[]

--- a/test-suite-java/src/main/java/helloworld/ReactiveGreetingEndpoint.java
+++ b/test-suite-java/src/main/java/helloworld/ReactiveGreetingEndpoint.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package helloworld;
+
+import jakarta.inject.Singleton;
+import reactor.core.publisher.Mono;
+
+// tag::reactive-service[]
+@Singleton
+public class ReactiveGreetingEndpoint extends ReactorReactiveGreeterGrpc.ReactiveGreeterImplBase {
+
+    private final GreetingService greetingService;
+
+    public ReactiveGreetingEndpoint(GreetingService greetingService) {
+        this.greetingService = greetingService;
+    }
+
+    @Override
+    public Mono<HelloReply> sayHello(Mono<HelloRequest> request) {
+        return request.map(helloRequest ->
+            HelloReply.newBuilder()
+                .setMessage(greetingService.sayHello(helloRequest.getName()))
+                .build()
+        );
+    }
+}
+// end::reactive-service[]

--- a/test-suite-java/src/main/proto/helloworld.proto
+++ b/test-suite-java/src/main/proto/helloworld.proto
@@ -26,7 +26,9 @@ service Greeter {
   rpc SayHello (HelloRequest) returns (HelloReply) {}
 }
 
-// The greeting service definition using reactive-grpc generated bindings.
+// A separate service definition used only to avoid registering two implementations of the
+// same service name in this test application. reactive-grpc generates Reactor bindings for
+// any standard gRPC service; a separate service definition is not required.
 service ReactiveGreeter {
   // Sends a greeting
   rpc SayHello (HelloRequest) returns (HelloReply) {}

--- a/test-suite-java/src/main/proto/helloworld.proto
+++ b/test-suite-java/src/main/proto/helloworld.proto
@@ -26,6 +26,12 @@ service Greeter {
   rpc SayHello (HelloRequest) returns (HelloReply) {}
 }
 
+// The greeting service definition using reactive-grpc generated bindings.
+service ReactiveGreeter {
+  // Sends a greeting
+  rpc SayHello (HelloRequest) returns (HelloReply) {}
+}
+
 // The request message containing the user's name.
 message HelloRequest {
   string name = 1;

--- a/test-suite-java/src/main/proto/reactivehelloworld.proto
+++ b/test-suite-java/src/main/proto/reactivehelloworld.proto
@@ -15,23 +15,17 @@ syntax = "proto3";
 
 option java_multiple_files = true;
 option java_package = "helloworld";
-option java_outer_classname = "HelloWorldProto";
-option objc_class_prefix = "HLW";
+option java_outer_classname = "ReactiveHelloWorldProto";
+option objc_class_prefix = "RHLW";
 
 package helloworld;
 
-// The greeting service definition.
-service Greeter {
+import "helloworld.proto";
+
+// A separate service definition used only to avoid registering two implementations of the
+// same service name in this test application. reactive-grpc generates Reactor bindings for
+// any standard gRPC service; a separate service definition is not required.
+service ReactiveGreeter {
   // Sends a greeting
   rpc SayHello (HelloRequest) returns (HelloReply) {}
-}
-
-// The request message containing the user's name.
-message HelloRequest {
-  string name = 1;
-}
-
-// The response message containing the greetings
-message HelloReply {
-  string message = 1;
 }

--- a/test-suite-java/src/test/java/helloworld/ReactiveGreetingEndpointTest.java
+++ b/test-suite-java/src/test/java/helloworld/ReactiveGreetingEndpointTest.java
@@ -25,6 +25,8 @@ import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 
+import java.time.Duration;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 // tag::reactive-test[]
@@ -39,7 +41,7 @@ class ReactiveGreetingEndpointTest {
         String message = Mono.just(HelloRequest.newBuilder().setName("Fred").build())
             .transform(reactiveStub::sayHello)
             .map(HelloReply::getMessage)
-            .block();
+            .block(Duration.ofSeconds(5));
 
         assertEquals("Hello Fred", message);
     }

--- a/test-suite-java/src/test/java/helloworld/ReactiveGreetingEndpointTest.java
+++ b/test-suite-java/src/test/java/helloworld/ReactiveGreetingEndpointTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package helloworld;
+
+import io.grpc.ManagedChannel;
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.grpc.annotation.GrpcChannel;
+import io.micronaut.grpc.server.GrpcServerChannel;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+// tag::reactive-test[]
+@MicronautTest
+class ReactiveGreetingEndpointTest {
+
+    @Inject
+    ReactorReactiveGreeterGrpc.ReactorReactiveGreeterStub reactiveStub;
+
+    @Test
+    void testReactiveHelloWorld() {
+        String message = Mono.just(HelloRequest.newBuilder().setName("Fred").build())
+            .transform(reactiveStub::sayHello)
+            .map(HelloReply::getMessage)
+            .block();
+
+        assertEquals("Hello Fred", message);
+    }
+}
+// end::reactive-test[]
+
+@Factory
+class ReactiveClients {
+
+    // tag::reactive-client[]
+    @Bean
+    ReactorReactiveGreeterGrpc.ReactorReactiveGreeterStub reactiveStub(
+        @GrpcChannel(GrpcServerChannel.NAME) ManagedChannel channel) {
+        return ReactorReactiveGreeterGrpc.newReactorStub(channel);
+    }
+    // end::reactive-client[]
+}


### PR DESCRIPTION
## Summary
- document how to generate and use Salesforce reactive-grpc Reactor stubs with Micronaut gRPC
- add a reactive service and client example in the Java test suite
- verify the documented setup with a focused Micronaut test

## Verification
- ./gradlew :test-suite-java:test --tests helloworld.ReactiveGreetingEndpointTest
- ./gradlew :test-suite-java:compileJava :test-suite-java:compileTestJava
- ./gradlew spotlessCheck
- git diff --check HEAD

Resolves #4
