### PR TITLE
Support configuring the gRPC server executor

### DIFF
--- a/grpc-server-runtime/src/main/java/io/micronaut/grpc/server/GrpcServerBuilder.java
+++ b/grpc-server-runtime/src/main/java/io/micronaut/grpc/server/GrpcServerBuilder.java
@@ -52,7 +52,17 @@ public class GrpcServerBuilder {
     private static final Logger LOG = LoggerFactory.getLogger(GrpcServerBuilder.class);
     @Nullable
     private final HealthStatusManagerContainer healthStatusManagerContainer;
+    @Nullable
     private final BeanContext beanContext;
+
+    /**
+     * Constructs the {@link ServerBuilder} instance.
+     *
+     * @param healthStatusManagerContainer if enabled, inject a GRPC health status manager.
+     */
+    public GrpcServerBuilder(@Nullable HealthStatusManagerContainer healthStatusManagerContainer) {
+        this(healthStatusManagerContainer, null);
+    }
 
     /**
      * Constructs the {@link ServerBuilder} instance.
@@ -87,6 +97,9 @@ public class GrpcServerBuilder {
                                              @Nullable List<ServerServiceDefinition> serverServiceDefinitions) {
         final ServerBuilder<?> serverBuilder = configuration.getServerBuilder();
         configuration.getExecutor().ifPresent(executorName -> {
+            if (beanContext == null) {
+                throw new ConfigurationException("A BeanContext is required to resolve the executor bean named [" + executorName + "]");
+            }
             Executor executor = beanContext.findBean(Executor.class, Qualifiers.byName(executorName))
                 .orElseThrow(() -> new ConfigurationException("No executor bean named [" + executorName + "] is available"));
             serverBuilder.executor(executor);

--- a/grpc-server-runtime/src/main/java/io/micronaut/grpc/server/GrpcServerBuilder.java
+++ b/grpc-server-runtime/src/main/java/io/micronaut/grpc/server/GrpcServerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package io.micronaut.grpc.server;
 
 import java.util.List;
+import java.util.concurrent.Executor;
 
 import io.grpc.BindableService;
 import io.grpc.ServerBuilder;
@@ -23,12 +24,15 @@ import io.grpc.ServerInterceptor;
 import io.grpc.ServerServiceDefinition;
 import io.grpc.ServerTransportFilter;
 import io.grpc.protobuf.services.HealthStatusManager;
+import io.micronaut.context.BeanContext;
 import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.exceptions.ConfigurationException;
 import org.jspecify.annotations.Nullable;
 import io.micronaut.core.order.OrderUtil;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.grpc.server.health.HealthStatusManagerContainer;
+import io.micronaut.inject.qualifiers.Qualifiers;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,15 +52,19 @@ public class GrpcServerBuilder {
     private static final Logger LOG = LoggerFactory.getLogger(GrpcServerBuilder.class);
     @Nullable
     private final HealthStatusManagerContainer healthStatusManagerContainer;
+    private final BeanContext beanContext;
 
     /**
      * Constructs the {@link ServerBuilder} instance.
      *
      * @param healthStatusManagerContainer if enabled, inject a GRPC health status manager.
+     * @param beanContext The bean context
      */
     @Inject
-    public GrpcServerBuilder(@Nullable HealthStatusManagerContainer healthStatusManagerContainer) {
+    public GrpcServerBuilder(@Nullable HealthStatusManagerContainer healthStatusManagerContainer,
+                             BeanContext beanContext) {
         this.healthStatusManagerContainer = healthStatusManagerContainer;
+        this.beanContext = beanContext;
     }
 
     /**
@@ -78,6 +86,11 @@ public class GrpcServerBuilder {
                                              @Nullable List<ServerTransportFilter> serverTransportFilters,
                                              @Nullable List<ServerServiceDefinition> serverServiceDefinitions) {
         final ServerBuilder<?> serverBuilder = configuration.getServerBuilder();
+        configuration.getExecutor().ifPresent(executorName -> {
+            Executor executor = beanContext.findBean(Executor.class, Qualifiers.byName(executorName))
+                .orElseThrow(() -> new ConfigurationException("No executor bean named [" + executorName + "] is available"));
+            serverBuilder.executor(executor);
+        });
         if (healthStatusManagerContainer != null) {
             HealthStatusManager healthStatusManager = healthStatusManagerContainer.getHealthStatusManager();
             if (LOG.isDebugEnabled()) {

--- a/grpc-server-runtime/src/main/java/io/micronaut/grpc/server/GrpcServerConfiguration.java
+++ b/grpc-server-runtime/src/main/java/io/micronaut/grpc/server/GrpcServerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@ public class GrpcServerConfiguration {
     public static final int DEFAULT_PORT = 50051;
     public static final Duration DEFAULT_AWAIT_TERMINATION = Duration.ofSeconds(30);
 
-    @ConfigurationBuilder(prefixes = "", excludes = "protocolNegotiator")
+    @ConfigurationBuilder(prefixes = "", excludes = {"protocolNegotiator", "executor"})
     protected final NettyServerBuilder serverBuilder;
     private final int serverPort;
     private final String serverHost;
@@ -66,6 +66,8 @@ public class GrpcServerConfiguration {
     private GrpcSslConfiguration serverConfiguration = new GrpcSslConfiguration();
     private boolean secure;
     private String instanceId = "";
+    @Nullable
+    private String executor;
     private Duration awaitTermination = DEFAULT_AWAIT_TERMINATION;
 
     /**
@@ -113,6 +115,24 @@ public class GrpcServerConfiguration {
      */
     public @NonNull ServerBuilder<?> getServerBuilder() {
         return serverBuilder;
+    }
+
+    /**
+     * The executor bean name.
+     *
+     * @return The executor bean name
+     */
+    public Optional<String> getExecutor() {
+        return Optional.ofNullable(executor);
+    }
+
+    /**
+     * Sets the executor bean name.
+     *
+     * @param executor The executor bean name
+     */
+    public void setExecutor(@Nullable String executor) {
+        this.executor = executor;
     }
 
     /**

--- a/grpc-server-runtime/src/test/groovy/io/micronaut/grpc/GrpcServerConfigurationSpec.groovy
+++ b/grpc-server-runtime/src/test/groovy/io/micronaut/grpc/GrpcServerConfigurationSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,20 @@ package io.micronaut.grpc
 
 import io.grpc.ServerBuilder
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Requires
 import io.micronaut.context.env.Environment
+import io.micronaut.context.exceptions.BeanInstantiationException
 import io.micronaut.core.io.ResourceResolver
 import io.micronaut.core.io.socket.SocketUtils
 import io.micronaut.grpc.server.GrpcServerConfiguration
+import io.micronaut.inject.qualifiers.Qualifiers
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Named
+import jakarta.inject.Singleton
 import spock.lang.Specification
+
+import java.util.concurrent.Executor
 
 @MicronautTest
 class GrpcServerConfigurationSpec extends Specification {
@@ -115,6 +123,71 @@ class GrpcServerConfigurationSpec extends Specification {
                 throw new ClassNotFoundException(name)
             }
             return super.loadClass(name, resolve)
+        }
+    }
+
+    void "test GRPC executor can be overridden with named bean configuration"() {
+        given:
+        def port = SocketUtils.findAvailableTcpPort()
+        def ctx = ApplicationContext.run([
+                'grpc.server.port'    : port,
+                'grpc.server.executor': 'grpc-test-executor',
+                'spec.name'           : 'GrpcServerConfigurationSpec'
+        ])
+
+        when:
+        GrpcServerConfiguration configuration = ctx.getBean(GrpcServerConfiguration)
+        Executor expectedExecutor = ctx.getBean(Executor, Qualifiers.byName('grpc-test-executor'))
+        ServerBuilder<?> serverBuilder = ctx.getBean(ServerBuilder)
+
+        then:
+        configuration.executor.get() == 'grpc-test-executor'
+        configuredExecutor(serverBuilder).is(expectedExecutor)
+
+        cleanup:
+        ctx.close()
+    }
+
+    void "test GRPC executor rejects unknown bean names"() {
+        given:
+        def ctx = ApplicationContext.run([
+                'grpc.server.executor': 'missing-executor'
+        ])
+
+        when:
+        ctx.getBean(ServerBuilder)
+
+        then:
+        def e = thrown(BeanInstantiationException)
+        e.message.contains('No executor bean named [missing-executor] is available')
+
+        cleanup:
+        ctx.close()
+    }
+
+    private static Executor configuredExecutor(ServerBuilder<?> serverBuilder) {
+        def serverImplBuilderField = serverBuilder.class.getDeclaredField('serverImplBuilder')
+        serverImplBuilderField.accessible = true
+        def serverImplBuilder = serverImplBuilderField.get(serverBuilder)
+        serverImplBuilder.getExecutorPool().getObject() as Executor
+    }
+
+    @Factory
+    @Requires(property = 'spec.name', value = 'GrpcServerConfigurationSpec')
+    static class TestExecutors {
+
+        @Singleton
+        @Named('grpc-test-executor')
+        Executor grpcTestExecutor() {
+            new TestExecutor()
+        }
+    }
+
+    static final class TestExecutor implements Executor {
+
+        @Override
+        void execute(Runnable command) {
+            command.run()
         }
     }
 }

--- a/grpc-server-runtime/src/test/groovy/io/micronaut/grpc/server/GrpcServerBuilderSpec.groovy
+++ b/grpc-server-runtime/src/test/groovy/io/micronaut/grpc/server/GrpcServerBuilderSpec.groovy
@@ -7,6 +7,7 @@ import io.grpc.ServerCallHandler
 import io.grpc.ServerInterceptor
 import io.grpc.internal.ServerImpl
 import io.grpc.netty.NettyServerBuilder
+import io.micronaut.context.BeanContext
 import io.micronaut.grpc.server.interceptor.OrderedServerInterceptor
 import spock.lang.Specification
 
@@ -14,7 +15,7 @@ class GrpcServerBuilderSpec extends Specification {
 
     def "test interceptor order - all implement Ordered"() {
         given:
-        GrpcServerBuilder grpcServerBuilder = new GrpcServerBuilder(null)
+        GrpcServerBuilder grpcServerBuilder = new GrpcServerBuilder(null, Mock(BeanContext))
 
         GrpcServerConfiguration mockGrpcConfiguration = Mock()
         List<ServerInterceptor> interceptors = [
@@ -30,6 +31,7 @@ class GrpcServerBuilderSpec extends Specification {
 
         then:
         1 * mockGrpcConfiguration.serverBuilder >> NettyServerBuilder.forPort(8080)
+        1 * mockGrpcConfiguration.getExecutor() >> Optional.empty()
         0 * _
 
         and:
@@ -53,7 +55,7 @@ class GrpcServerBuilderSpec extends Specification {
 
     def "test interceptor order - some implement Ordered"() {
         given:
-        GrpcServerBuilder grpcServerBuilder = new GrpcServerBuilder(null)
+        GrpcServerBuilder grpcServerBuilder = new GrpcServerBuilder(null, Mock(BeanContext))
 
         GrpcServerConfiguration mockGrpcConfiguration = Mock()
         List<ServerInterceptor> interceptors = [
@@ -69,6 +71,7 @@ class GrpcServerBuilderSpec extends Specification {
 
         then:
         1 * mockGrpcConfiguration.serverBuilder >> NettyServerBuilder.forPort(8080)
+        1 * mockGrpcConfiguration.getExecutor() >> Optional.empty()
         0 * _
 
         and:
@@ -92,7 +95,7 @@ class GrpcServerBuilderSpec extends Specification {
 
     def "test interceptor order - none implement Ordered"() {
         given:
-        GrpcServerBuilder grpcServerBuilder = new GrpcServerBuilder(null)
+        GrpcServerBuilder grpcServerBuilder = new GrpcServerBuilder(null, Mock(BeanContext))
 
         GrpcServerConfiguration mockGrpcConfiguration = Mock()
         List<ServerInterceptor> interceptors = [
@@ -108,6 +111,7 @@ class GrpcServerBuilderSpec extends Specification {
 
         then:
         1 * mockGrpcConfiguration.serverBuilder >> NettyServerBuilder.forPort(8080)
+        1 * mockGrpcConfiguration.getExecutor() >> Optional.empty()
         0 * _
 
         and:

--- a/grpc-server-runtime/src/test/groovy/io/micronaut/grpc/server/GrpcServerBuilderSpec.groovy
+++ b/grpc-server-runtime/src/test/groovy/io/micronaut/grpc/server/GrpcServerBuilderSpec.groovy
@@ -7,7 +7,6 @@ import io.grpc.ServerCallHandler
 import io.grpc.ServerInterceptor
 import io.grpc.internal.ServerImpl
 import io.grpc.netty.NettyServerBuilder
-import io.micronaut.context.BeanContext
 import io.micronaut.grpc.server.interceptor.OrderedServerInterceptor
 import spock.lang.Specification
 
@@ -15,7 +14,7 @@ class GrpcServerBuilderSpec extends Specification {
 
     def "test interceptor order - all implement Ordered"() {
         given:
-        GrpcServerBuilder grpcServerBuilder = new GrpcServerBuilder(null, Mock(BeanContext))
+        GrpcServerBuilder grpcServerBuilder = new GrpcServerBuilder(null)
 
         GrpcServerConfiguration mockGrpcConfiguration = Mock()
         List<ServerInterceptor> interceptors = [
@@ -55,7 +54,7 @@ class GrpcServerBuilderSpec extends Specification {
 
     def "test interceptor order - some implement Ordered"() {
         given:
-        GrpcServerBuilder grpcServerBuilder = new GrpcServerBuilder(null, Mock(BeanContext))
+        GrpcServerBuilder grpcServerBuilder = new GrpcServerBuilder(null)
 
         GrpcServerConfiguration mockGrpcConfiguration = Mock()
         List<ServerInterceptor> interceptors = [
@@ -95,7 +94,7 @@ class GrpcServerBuilderSpec extends Specification {
 
     def "test interceptor order - none implement Ordered"() {
         given:
-        GrpcServerBuilder grpcServerBuilder = new GrpcServerBuilder(null, Mock(BeanContext))
+        GrpcServerBuilder grpcServerBuilder = new GrpcServerBuilder(null)
 
         GrpcServerConfiguration mockGrpcConfiguration = Mock()
         List<ServerInterceptor> interceptors = [

--- a/src/main/docs/guide/server.adoc
+++ b/src/main/docs/guide/server.adoc
@@ -57,6 +57,7 @@ By default, the server will automatically be dependency injected with beans of t
 * `io.grpc.ServerTransportFilter` - Any transport filters declared as beans
 
 In addition, by default the server will be setup to use Micronaut's I/O executor service.
+Set `grpc.server.executor` to the name of an `Executor` bean to override that default from configuration.
 
 ==== Server Interceptor Ordering
 To produce a consistent and predictable order of execution for server interceptors, it is required


### PR DESCRIPTION
## Summary
- allow `grpc.server.executor` to bind as a bean name without changing global `String -> Executor` conversion behavior
- resolve the configured executor when `GrpcServerBuilder` consumes `GrpcServerConfiguration`
- document the new configuration option and cover both successful and failing resolution paths in tests

## Verification
- `./gradlew :micronaut-grpc-server-runtime:test --tests io.micronaut.grpc.GrpcServerConfigurationSpec --tests io.micronaut.grpc.server.GrpcServerBuilderSpec --rerun-tasks`

Resolves https://github.com/micronaut-projects/micronaut-grpc/issues/1097
