### PR TITLE
Add gRPC client default service config binding

### DIFF
--- a/grpc-client-runtime/src/main/java/io/micronaut/grpc/channels/GrpcDefaultManagedChannelConfiguration.java
+++ b/grpc-client-runtime/src/main/java/io/micronaut/grpc/channels/GrpcDefaultManagedChannelConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ public class GrpcDefaultManagedChannelConfiguration extends GrpcManagedChannelCo
     public GrpcDefaultManagedChannelConfiguration(
         Environment env,
         @Named(TaskExecutors.IO) ExecutorService executorService) {
-        super(NAME, env, executorService);
+        super(NAME, PREFIX, env, executorService);
     }
 
     /**
@@ -58,6 +58,6 @@ public class GrpcDefaultManagedChannelConfiguration extends GrpcManagedChannelCo
         String target,
         Environment env,
         @Named(TaskExecutors.IO) ExecutorService executorService) {
-        super(target, env, executorService);
+        super(target, PREFIX, env, executorService);
     }
 }

--- a/grpc-client-runtime/src/main/java/io/micronaut/grpc/channels/GrpcManagedChannelConfiguration.java
+++ b/grpc-client-runtime/src/main/java/io/micronaut/grpc/channels/GrpcManagedChannelConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,14 @@ package io.micronaut.grpc.channels;
 import io.grpc.netty.NettyChannelBuilder;
 import io.micronaut.context.annotation.ConfigurationBuilder;
 import io.micronaut.context.env.Environment;
+import io.micronaut.core.convert.format.MapFormat;
 import io.micronaut.core.naming.Named;
+import io.micronaut.core.naming.conventions.StringConvention;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.URI;
@@ -42,7 +48,7 @@ public abstract class GrpcManagedChannelConfiguration implements Named {
     private static final Duration DEFAULT_CONNECTION_TIMEOUT = Duration.ofSeconds(20);
     protected final String name;
 
-    @ConfigurationBuilder(prefixes = {"use", ""}, allowZeroArgs = true)
+    @ConfigurationBuilder(prefixes = {"use", ""}, allowZeroArgs = true, excludes = {"defaultServiceConfig"})
     protected final NettyChannelBuilder channelBuilder;
 
     private final boolean connectOnStartup;
@@ -55,17 +61,17 @@ public abstract class GrpcManagedChannelConfiguration implements Named {
      * @param env             The environment
      * @param executorService The executor service to use
      */
-    protected GrpcManagedChannelConfiguration(String name, Environment env, ExecutorService executorService) {
+    protected GrpcManagedChannelConfiguration(String name, String propertyPrefix, Environment env, ExecutorService executorService) {
         this.name = name;
-        this.connectOnStartup = env.getProperty(PREFIX + '.' + name + CONNECT_ON_STARTUP, Boolean.class).isPresent();
-        this.connectionTimeout = env.getProperty(PREFIX + '.' + name + CONNECTION_TIMEOUT, Long.class)
+        this.connectOnStartup = env.getProperty(propertyPrefix + CONNECT_ON_STARTUP, Boolean.class).isPresent();
+        this.connectionTimeout = env.getProperty(propertyPrefix + CONNECTION_TIMEOUT, Long.class)
             .filter(t -> t > 0)
             .map(Duration::ofSeconds)
             .orElse(DEFAULT_CONNECTION_TIMEOUT);
 
-        this.channelBuilder = env.getProperty(PREFIX + '.' + name + SETTING_URL, SocketAddress.class)
+        this.channelBuilder = env.getProperty(propertyPrefix + SETTING_URL, SocketAddress.class)
             .map(this::getChannelBuilder)
-            .orElseGet(() -> env.getProperty(PREFIX + '.' + name + SETTING_TARGET, String.class)
+            .orElseGet(() -> env.getProperty(propertyPrefix + SETTING_TARGET, String.class)
                 .map(NettyChannelBuilder::forTarget)
                 .orElseGet(() -> {
                     final URI uri = name.contains("//") ? URI.create(name) : null;
@@ -127,5 +133,47 @@ public abstract class GrpcManagedChannelConfiguration implements Named {
      */
     public NettyChannelBuilder getChannelBuilder() {
         return channelBuilder;
+    }
+
+    /**
+     * Applies the gRPC default service config using Micronaut's nested/raw map binding.
+     *
+     * @param serviceConfig The service config map
+     */
+    public void setDefaultServiceConfig(
+        @MapFormat(transformation = MapFormat.MapTransformation.NESTED, keyFormat = StringConvention.RAW)
+        Map<String, Object> serviceConfig) {
+        if (serviceConfig != null) {
+            channelBuilder.defaultServiceConfig(normalizeServiceConfig(serviceConfig));
+        }
+    }
+
+    private Map<String, ?> normalizeServiceConfig(Map<String, Object> serviceConfig) {
+        Map<String, Object> normalized = new LinkedHashMap<>(serviceConfig.size());
+        for (Map.Entry<String, Object> entry : serviceConfig.entrySet()) {
+            normalized.put(entry.getKey(), normalizeServiceConfigValue(entry.getValue()));
+        }
+        return normalized;
+    }
+
+    private Object normalizeServiceConfigValue(Object value) {
+        if (value instanceof Map<?, ?> map) {
+            Map<String, Object> normalized = new LinkedHashMap<>(map.size());
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                normalized.put(String.valueOf(entry.getKey()), normalizeServiceConfigValue(entry.getValue()));
+            }
+            return normalized;
+        }
+        if (value instanceof List<?> list) {
+            List<Object> normalized = new ArrayList<>(list.size());
+            for (Object entry : list) {
+                normalized.add(normalizeServiceConfigValue(entry));
+            }
+            return normalized;
+        }
+        if (value instanceof Number number && !(value instanceof Double)) {
+            return number.doubleValue();
+        }
+        return value;
     }
 }

--- a/grpc-client-runtime/src/main/java/io/micronaut/grpc/channels/GrpcManagedChannelConfiguration.java
+++ b/grpc-client-runtime/src/main/java/io/micronaut/grpc/channels/GrpcManagedChannelConfiguration.java
@@ -18,6 +18,7 @@ package io.micronaut.grpc.channels;
 import io.grpc.netty.NettyChannelBuilder;
 import io.micronaut.context.annotation.ConfigurationBuilder;
 import io.micronaut.context.env.Environment;
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.convert.format.MapFormat;
 import io.micronaut.core.naming.Named;
 import io.micronaut.core.naming.conventions.StringConvention;
@@ -55,12 +56,27 @@ public abstract class GrpcManagedChannelConfiguration implements Named {
     private final Duration connectionTimeout;
 
     /**
-     * Constructors a new managed channel configuration.
+     * Constructs a new managed channel configuration.
      *
      * @param name            The name
      * @param env             The environment
      * @param executorService The executor service to use
+     * @deprecated Use {@link #GrpcManagedChannelConfiguration(String, String, Environment, ExecutorService)} instead
      */
+    @Deprecated(since = "4.9.0", forRemoval = true)
+    protected GrpcManagedChannelConfiguration(String name, Environment env, ExecutorService executorService) {
+        this(name, PREFIX + '.' + name, env, executorService);
+    }
+
+    /**
+     * Constructs a new managed channel configuration.
+     *
+     * @param name            The name
+     * @param propertyPrefix  The property prefix for reading environment configuration
+     * @param env             The environment
+     * @param executorService The executor service to use
+     */
+    @Internal
     protected GrpcManagedChannelConfiguration(String name, String propertyPrefix, Environment env, ExecutorService executorService) {
         this.name = name;
         this.connectOnStartup = env.getProperty(propertyPrefix + CONNECT_ON_STARTUP, Boolean.class).isPresent();

--- a/grpc-client-runtime/src/main/java/io/micronaut/grpc/channels/GrpcNamedManagedChannelConfiguration.java
+++ b/grpc-client-runtime/src/main/java/io/micronaut/grpc/channels/GrpcNamedManagedChannelConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,6 @@ public class GrpcNamedManagedChannelConfiguration extends GrpcManagedChannelConf
         @Parameter String name,
         Environment env,
         @Named(TaskExecutors.IO) ExecutorService executorService) {
-        super(name, env, executorService);
+        super(name, PREFIX + '.' + name, env, executorService);
     }
 }

--- a/grpc-client-runtime/src/test/groovy/io/micronaut/grpc/GrpcNamedChannelSpec.groovy
+++ b/grpc-client-runtime/src/test/groovy/io/micronaut/grpc/GrpcNamedChannelSpec.groovy
@@ -323,8 +323,16 @@ class GrpcNamedChannelSpec extends Specification {
     }
 
     private static Object getFieldValue(Object target, String fieldName) {
-        def field = target.class.getDeclaredField(fieldName)
-        field.accessible = true
-        field.get(target)
+        Class<?> currentClass = target.class
+        while (currentClass != null) {
+            try {
+                def field = currentClass.getDeclaredField(fieldName)
+                field.setAccessible(true)
+                return field.get(target)
+            } catch (NoSuchFieldException ignored) {
+                currentClass = currentClass.getSuperclass()
+            }
+        }
+        throw new NoSuchFieldException("Field '${fieldName}' not found on ${target.class.name} or its superclasses")
     }
 }

--- a/grpc-client-runtime/src/test/groovy/io/micronaut/grpc/GrpcNamedChannelSpec.groovy
+++ b/grpc-client-runtime/src/test/groovy/io/micronaut/grpc/GrpcNamedChannelSpec.groovy
@@ -4,6 +4,7 @@ import io.grpc.Channel
 import io.grpc.examples.helloworld.Greeter2Grpc
 import io.grpc.examples.helloworld.HelloReply
 import io.grpc.examples.helloworld.HelloRequest
+import io.grpc.netty.NettyChannelBuilder
 import io.grpc.stub.StreamObserver
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Factory
@@ -151,6 +152,101 @@ class GrpcNamedChannelSpec extends Specification {
         embeddedServer.close()
     }
 
+    void "test named client configures retry service config"() {
+        given:
+        def context = ApplicationContext.run([
+                'grpc.channels.greeter.address'               : "localhost:${SocketUtils.findAvailableTcpPort()}",
+                'grpc.channels.greeter.plaintext'             : true,
+                'grpc.channels.greeter.enable-retry'          : true,
+                'grpc.channels.greeter.max-retry-attempts'    : 4,
+                'grpc.channels.greeter.max-hedged-attempts'   : 3,
+                'grpc.channels.greeter.retry-buffer-size'     : 1024,
+                'grpc.channels.greeter.per-rpc-buffer-limit'  : 512,
+                'grpc.channels.greeter.default-service-config': [
+                        methodConfig: [[
+                                name       : [[service: 'helloworld.Greeter']],
+                                retryPolicy: [
+                                        maxAttempts         : 4,
+                                        initialBackoff      : '0.1s',
+                                        maxBackoff          : '1s',
+                                        backoffMultiplier   : 2,
+                                        retryableStatusCodes: ['UNAVAILABLE']
+                                ]
+                        ]]
+                ]
+        ])
+
+        when:
+        def config = context.getBean(GrpcManagedChannelConfiguration, Qualifiers.byName("greeter"))
+        def managedChannelBuilder = getFieldValue(config.channelBuilder, "managedChannelImplBuilder")
+
+        then:
+        getFieldValue(managedChannelBuilder, "retryEnabled")
+        getFieldValue(managedChannelBuilder, "maxRetryAttempts") == 4
+        getFieldValue(managedChannelBuilder, "maxHedgedAttempts") == 3
+        getFieldValue(managedChannelBuilder, "retryBufferSize") == 1024L
+        getFieldValue(managedChannelBuilder, "perRpcBufferLimit") == 512L
+        getFieldValue(managedChannelBuilder, "defaultServiceConfig") == [
+                methodConfig: [[
+                        name       : [[service: 'helloworld.Greeter']],
+                        retryPolicy: [
+                                maxAttempts         : 4d,
+                                initialBackoff      : '0.1s',
+                                maxBackoff          : '1s',
+                                backoffMultiplier   : 2d,
+                                retryableStatusCodes: ['UNAVAILABLE']
+                        ]
+                ]]
+        ]
+
+        cleanup:
+        context.close()
+    }
+
+    void "test default client configures retry service config"() {
+        given:
+        def context = ApplicationContext.run([
+                'grpc.client.plaintext'             : true,
+                'grpc.client.enable-retry'          : true,
+                'grpc.client.max-retry-attempts'    : 4,
+                'grpc.client.default-service-config': [
+                        methodConfig: [[
+                                name       : [[service: 'helloworld.Greeter']],
+                                retryPolicy: [
+                                        maxAttempts         : 4,
+                                        initialBackoff      : '0.1s',
+                                        maxBackoff          : '1s',
+                                        backoffMultiplier   : 2,
+                                        retryableStatusCodes: ['UNAVAILABLE']
+                                ]
+                        ]]
+                ]
+        ])
+
+        when:
+        def channelBuilder = context.createBean(NettyChannelBuilder, "http://localhost:${SocketUtils.findAvailableTcpPort()}")
+        def managedChannelBuilder = getFieldValue(channelBuilder, "managedChannelImplBuilder")
+
+        then:
+        getFieldValue(managedChannelBuilder, "retryEnabled")
+        getFieldValue(managedChannelBuilder, "maxRetryAttempts") == 4
+        getFieldValue(managedChannelBuilder, "defaultServiceConfig") == [
+                methodConfig: [[
+                        name       : [[service: 'helloworld.Greeter']],
+                        retryPolicy: [
+                                maxAttempts         : 4d,
+                                initialBackoff      : '0.1s',
+                                maxBackoff          : '1s',
+                                backoffMultiplier   : 2d,
+                                retryableStatusCodes: ['UNAVAILABLE']
+                        ]
+                ]]
+        ]
+
+        cleanup:
+        context.close()
+    }
+
     @Retry
     void "test named client - eager init"() {
         given:
@@ -224,5 +320,11 @@ class GrpcNamedChannelSpec extends Specification {
             responseObserver.onNext(reply)
             responseObserver.onCompleted()
         }
+    }
+
+    private static Object getFieldValue(Object target, String fieldName) {
+        def field = target.class.getDeclaredField(fieldName)
+        field.accessible = true
+        field.get(target)
     }
 }

--- a/src/main/docs/guide/client.adoc
+++ b/src/main/docs/guide/client.adoc
@@ -8,7 +8,7 @@ The channel can be configured using properties defined under `grpc.client` by de
 
 For example, if you wish to disable secure communication:
 
-[source,yaml]
+[configuration]
 ----
 grpc:
     client:
@@ -38,6 +38,32 @@ grpc:
 ----
 
 When a client is disabled, optional or nullable `@GrpcChannel` injection points resolve to an empty value, while required injection points fail with a dependency injection error.
+
+For gRPC service-config based retry and resiliency features, you can configure `default-service-config` as a nested map. The map is bound using Micronaut's nested/raw map binding so gRPC service config keys such as `methodConfig`, `retryPolicy`, and `hedgingPolicy` are preserved as-is.
+
+[configuration]
+----
+grpc:
+    client:
+        plaintext: true
+        enable-retry: true
+        max-retry-attempts: 4
+        default-service-config:
+            methodConfig:
+                -
+                    name:
+                        -
+                            service: helloworld.Greeter
+                    retryPolicy:
+                        maxAttempts: 4
+                        initialBackoff: 0.1s
+                        maxBackoff: 1s
+                        backoffMultiplier: 2
+                        retryableStatusCodes:
+                            - UNAVAILABLE
+----
+
+The same structure can be defined per channel under `grpc.channels.<name>.default-service-config`.
 
 Alternatively if you prefer programmatic configuration you can write a `BeanCreationListener` for example:
 
@@ -77,14 +103,28 @@ The above example requires that `my.server` and `my.port` are specified in `appl
 
 For example given the following configuration:
 
-[source,yaml]
+[configuration]
 ----
 grpc:
     channels:
         greeter:
             address: '${my.server}:${my.port}'
             plaintext: true
+            enable-retry: true
             max-retry-attempts: 10
+            default-service-config:
+                methodConfig:
+                    -
+                        name:
+                            -
+                                service: helloworld.Greeter
+                        retryPolicy:
+                            maxAttempts: 4
+                            initialBackoff: 0.1s
+                            maxBackoff: 1s
+                            backoffMultiplier: 2
+                            retryableStatusCodes:
+                                - UNAVAILABLE
 ----
 
 You can then define the `@GrpcChannel` annotation as follows:

--- a/src/main/docs/guide/client.adoc
+++ b/src/main/docs/guide/client.adoc
@@ -111,7 +111,7 @@ grpc:
             address: '${my.server}:${my.port}'
             plaintext: true
             enable-retry: true
-            max-retry-attempts: 10
+            max-retry-attempts: 4
             default-service-config:
                 methodConfig:
                     -


### PR DESCRIPTION
## Summary
- add explicit `defaultServiceConfig` binding for gRPC clients using nested/raw Micronaut map binding
- normalize nested service config numbers so grpc-java accepts retry and resiliency policies
- document `default-service-config` usage for global and named gRPC channels

## Verification
- ./gradlew :micronaut-grpc-client-runtime:test

Resolves #695
