### PR TITLE
Add experimental gRPC-Web support

### DIFF
--- a/protobuff-json-support/src/main/java/io/micronaut/protobuf/json/GrpcWebController.java
+++ b/protobuff-json-support/src/main/java/io/micronaut/protobuf/json/GrpcWebController.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.protobuf.json;
+
+import com.google.protobuf.Message;
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.http.HttpHeaders;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.MutableHttpResponse;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Header;
+import io.micronaut.http.annotation.PathVariable;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.exceptions.HttpStatusException;
+import io.micronaut.protobuf.json.exception.GrpcInvocationException;
+import io.micronaut.protobuf.json.exception.MethodNotFoundException;
+import io.micronaut.protobuf.json.exception.ServiceNotFoundException;
+import io.micronaut.protobuf.json.grpc.GrpcProxyService;
+import jakarta.inject.Singleton;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+
+/**
+ * HTTP/1.1 bridge that exposes annotated gRPC services via the gRPC-Web wire protocol.
+ */
+@Experimental
+@Singleton
+@Controller("/${micronaut.grpc.web.path:`grpc-web`}")
+public final class GrpcWebController {
+    static final String GRPC_WEB_PROTO = "application/grpc-web+proto";
+    static final String GRPC_WEB_TEXT_PROTO = "application/grpc-web-text+proto";
+    private static final byte TRAILER_FRAME = (byte) 0x80;
+    private static final byte COMPRESSED_FRAME = 0x01;
+
+    private final GrpcProxyService grpcProxyService;
+
+    public GrpcWebController(GrpcProxyService grpcProxyService) {
+        this.grpcProxyService = grpcProxyService;
+    }
+
+    @Post(
+        uri = "/{serviceName}/{methodName}",
+        consumes = {GRPC_WEB_PROTO, GRPC_WEB_TEXT_PROTO},
+        produces = {GRPC_WEB_PROTO, GRPC_WEB_TEXT_PROTO}
+    )
+    public HttpResponse<byte[]> invokeMethod(@PathVariable String serviceName,
+                                             @PathVariable String methodName,
+                                             @Body byte[] requestBody,
+                                             @Header(HttpHeaders.CONTENT_TYPE) String contentType) {
+        boolean textEncoded = isTextEncoded(contentType);
+        try {
+            byte[] grpcPayload = decodeRequestBody(requestBody, textEncoded);
+            Message requestMessage = grpcProxyService.parseRequestMessage(serviceName, methodName, extractMessage(grpcPayload));
+            List<Message> responses = grpcProxyService.invokeGrpcMethod(serviceName, methodName, requestMessage);
+            return successResponse(responses, textEncoded);
+        } catch (MethodNotFoundException | ServiceNotFoundException e) {
+            return errorResponse(textEncoded, 12, e.getMessage());
+        } catch (GrpcInvocationException e) {
+            return errorResponse(textEncoded, 13, e.getMessage());
+        } catch (HttpStatusException e) {
+            return errorResponse(textEncoded, 3, e.getMessage());
+        }
+    }
+
+    private MutableHttpResponse<byte[]> successResponse(List<Message> responses, boolean textEncoded) {
+        byte[] responseBody = encodeResponseBody(responses, 0, null, textEncoded);
+        return baseResponse(responseBody, textEncoded)
+            .header("grpc-status", "0");
+    }
+
+    private MutableHttpResponse<byte[]> errorResponse(boolean textEncoded, int grpcStatus, String grpcMessage) {
+        return baseResponse(encodeResponseBody(List.of(), grpcStatus, grpcMessage, textEncoded), textEncoded)
+            .header("grpc-status", Integer.toString(grpcStatus))
+            .header("grpc-message", sanitizeHeaderValue(grpcMessage));
+    }
+
+    private MutableHttpResponse<byte[]> baseResponse(byte[] body, boolean textEncoded) {
+        return HttpResponse.ok(body)
+            .contentType(MediaType.of(textEncoded ? GRPC_WEB_TEXT_PROTO : GRPC_WEB_PROTO))
+            .header("x-grpc-web", "1")
+            .header("access-control-expose-headers", "grpc-status,grpc-message")
+            .header("trailer", "grpc-status,grpc-message");
+    }
+
+    private byte[] decodeRequestBody(byte[] requestBody, boolean textEncoded) {
+        if (!textEncoded) {
+            return requestBody;
+        }
+        try {
+            return Base64.getDecoder().decode(requestBody);
+        } catch (IllegalArgumentException e) {
+            throw new HttpStatusException(HttpStatus.BAD_REQUEST, "Malformed base64 gRPC-Web request");
+        }
+    }
+
+    private byte[] extractMessage(byte[] grpcPayload) {
+        if (grpcPayload.length < 5) {
+            throw new HttpStatusException(HttpStatus.BAD_REQUEST, "gRPC-Web request body is too short");
+        }
+        ByteBuffer buffer = ByteBuffer.wrap(grpcPayload);
+        byte flags = buffer.get();
+        if ((flags & TRAILER_FRAME) != 0) {
+            throw new HttpStatusException(HttpStatus.BAD_REQUEST, "gRPC-Web request must start with a data frame");
+        }
+        if ((flags & COMPRESSED_FRAME) != 0) {
+            throw new HttpStatusException(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "Compressed gRPC-Web requests are not supported");
+        }
+        int length = buffer.getInt();
+        if (length < 0 || buffer.remaining() != length) {
+            throw new HttpStatusException(HttpStatus.BAD_REQUEST, "Malformed gRPC-Web frame length");
+        }
+        byte[] message = new byte[length];
+        buffer.get(message);
+        return message;
+    }
+
+    private byte[] encodeResponseBody(List<Message> messages, int grpcStatus, String grpcMessage, boolean textEncoded) {
+        byte[] binaryBody = encodeBinaryResponse(messages, grpcStatus, grpcMessage);
+        if (!textEncoded) {
+            return binaryBody;
+        }
+        return Base64.getEncoder().encode(binaryBody);
+    }
+
+    private byte[] encodeBinaryResponse(List<Message> messages, int grpcStatus, String grpcMessage) {
+        byte[] trailers = trailerFrame(grpcStatus, grpcMessage);
+        int totalLength = trailers.length;
+        for (Message message : messages) {
+            totalLength += 5 + message.getSerializedSize();
+        }
+        ByteBuffer buffer = ByteBuffer.allocate(totalLength);
+        for (Message message : messages) {
+            byte[] payload = message.toByteArray();
+            buffer.put((byte) 0);
+            buffer.putInt(payload.length);
+            buffer.put(payload);
+        }
+        buffer.put(trailers);
+        return buffer.array();
+    }
+
+    private byte[] trailerFrame(int grpcStatus, String grpcMessage) {
+        StringBuilder trailers = new StringBuilder("grpc-status:").append(grpcStatus).append("\r\n");
+        if (grpcMessage != null && !grpcMessage.isBlank()) {
+            trailers.append("grpc-message:").append(sanitizeHeaderValue(grpcMessage)).append("\r\n");
+        }
+        byte[] payload = trailers.toString().getBytes(StandardCharsets.US_ASCII);
+        ByteBuffer buffer = ByteBuffer.allocate(5 + payload.length);
+        buffer.put(TRAILER_FRAME);
+        buffer.putInt(payload.length);
+        buffer.put(payload);
+        return buffer.array();
+    }
+
+    private boolean isTextEncoded(String contentType) {
+        return contentType != null && contentType.startsWith(GRPC_WEB_TEXT_PROTO);
+    }
+
+    private String sanitizeHeaderValue(String value) {
+        return value == null ? "" : value.replace('\r', ' ').replace('\n', ' ');
+    }
+}

--- a/protobuff-json-support/src/main/java/io/micronaut/protobuf/json/GrpcWebController.java
+++ b/protobuff-json-support/src/main/java/io/micronaut/protobuf/json/GrpcWebController.java
@@ -34,6 +34,7 @@ import io.micronaut.protobuf.json.exception.ServiceNotFoundException;
 import io.micronaut.protobuf.json.grpc.GrpcProxyService;
 import jakarta.inject.Singleton;
 
+import java.net.URLEncoder;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -90,7 +91,7 @@ public final class GrpcWebController {
     private MutableHttpResponse<byte[]> errorResponse(boolean textEncoded, int grpcStatus, String grpcMessage) {
         return baseResponse(encodeResponseBody(List.of(), grpcStatus, grpcMessage, textEncoded), textEncoded)
             .header("grpc-status", Integer.toString(grpcStatus))
-            .header("grpc-message", sanitizeHeaderValue(grpcMessage));
+            .header("grpc-message", percentEncodeMessage(grpcMessage));
     }
 
     private MutableHttpResponse<byte[]> baseResponse(byte[] body, boolean textEncoded) {
@@ -161,7 +162,7 @@ public final class GrpcWebController {
     private byte[] trailerFrame(int grpcStatus, String grpcMessage) {
         StringBuilder trailers = new StringBuilder("grpc-status:").append(grpcStatus).append("\r\n");
         if (grpcMessage != null && !grpcMessage.isBlank()) {
-            trailers.append("grpc-message:").append(sanitizeHeaderValue(grpcMessage)).append("\r\n");
+            trailers.append("grpc-message:").append(percentEncodeMessage(grpcMessage)).append("\r\n");
         }
         byte[] payload = trailers.toString().getBytes(StandardCharsets.US_ASCII);
         ByteBuffer buffer = ByteBuffer.allocate(5 + payload.length);
@@ -175,7 +176,10 @@ public final class GrpcWebController {
         return contentType != null && contentType.startsWith(GRPC_WEB_TEXT_PROTO);
     }
 
-    private String sanitizeHeaderValue(String value) {
-        return value == null ? "" : value.replace('\r', ' ').replace('\n', ' ');
+    private static String percentEncodeMessage(String value) {
+        if (value == null) {
+            return "";
+        }
+        return URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20");
     }
 }

--- a/protobuff-json-support/src/main/java/io/micronaut/protobuf/json/GrpcWebController.java
+++ b/protobuff-json-support/src/main/java/io/micronaut/protobuf/json/GrpcWebController.java
@@ -34,7 +34,6 @@ import io.micronaut.protobuf.json.exception.ServiceNotFoundException;
 import io.micronaut.protobuf.json.grpc.GrpcProxyService;
 import jakarta.inject.Singleton;
 
-import java.net.URLEncoder;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -180,6 +179,18 @@ public final class GrpcWebController {
         if (value == null) {
             return "";
         }
-        return URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20");
+        // gRPC grpc-message percent-encoding per the gRPC HTTP/2 spec:
+        // allow printable ASCII 0x20–0x7E except '%' (0x25) unencoded; encode everything else.
+        var bytes = value.getBytes(StandardCharsets.UTF_8);
+        var sb = new StringBuilder(bytes.length * 3);
+        for (byte b : bytes) {
+            int c = b & 0xFF;
+            if (c >= 0x20 && c <= 0x7E && c != '%') {
+                sb.append((char) c);
+            } else {
+                sb.append(String.format("%%%02X", c));
+            }
+        }
+        return sb.toString();
     }
 }

--- a/protobuff-json-support/src/main/java/io/micronaut/protobuf/json/grpc/GrpcProxyService.java
+++ b/protobuff-json-support/src/main/java/io/micronaut/protobuf/json/grpc/GrpcProxyService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2025 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import jakarta.inject.Singleton;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-// Added imports
+import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -101,57 +101,83 @@ public class GrpcProxyService {
      * @throws GrpcInvocationException If the invocation of the gRPC method fails or times out.
      */
     public String invokeGrpcMethod(String serviceName, String methodName, String jsonRequest) {
-        // Obtain the executable method
-        ExecutableMethod<?, ?> grpcMethod = registry.getExecutableMethod(serviceName, methodName)
+        ExecutableMethod<?, ?> grpcMethod = resolveGrpcMethod(serviceName, methodName);
+        Message requestMessage = transcoder.fromJson(jsonRequest, resolveRequestType(grpcMethod));
+        return toJson(invokeGrpcMethod(serviceName, methodName, requestMessage));
+    }
+
+    /**
+     * Invokes a specified gRPC method on a service using a protobuf request.
+     *
+     * @param serviceName The gRPC service name.
+     * @param methodName The gRPC method name.
+     * @param requestMessage The protobuf request.
+     * @return The protobuf responses emitted by the method.
+     */
+    public List<Message> invokeGrpcMethod(String serviceName, String methodName, Message requestMessage) {
+        ExecutableMethod<?, ?> grpcMethod = resolveGrpcMethod(serviceName, methodName);
+        Object beanInstance = resolveBeanInstance(serviceName, grpcMethod);
+        final List<Message> responseMessages;
+        try {
+            responseMessages = invokeGrpcMethodReflectively(beanInstance, (ExecutableMethod<Object, Object>) grpcMethod, requestMessage);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new GrpcInvocationException("gRPC method invocation was interrupted: " + e.getMessage(), e);
+        }
+        return responseMessages;
+    }
+
+    /**
+     * Parses a protobuf request payload for the given gRPC method.
+     *
+     * @param serviceName The gRPC service name.
+     * @param methodName The gRPC method name.
+     * @param requestBytes The protobuf request bytes.
+     * @return The decoded request message.
+     */
+    public Message parseRequestMessage(String serviceName, String methodName, byte[] requestBytes) {
+        GrpcServiceRegistry.RegisteredMethod registeredMethod = resolveRegisteredMethod(serviceName, methodName);
+        return (Message) registeredMethod.methodDescriptor().getRequestMarshaller()
+            .parse(new ByteArrayInputStream(requestBytes));
+    }
+
+    private String toJson(List<Message> responseMessages) {
+        if (responseMessages.isEmpty()) {
+            return "[]";
+        } else if (responseMessages.size() == 1) {
+            return transcoder.toJson(responseMessages.get(0));
+        } else {
+            List<String> jsonResponses = responseMessages.stream()
+                .map(transcoder::toJson)
+                .collect(Collectors.toList());
+            return "[" + String.join(",", jsonResponses) + "]";
+        }
+    }
+
+    private ExecutableMethod<?, ?> resolveGrpcMethod(String serviceName, String methodName) {
+        return resolveRegisteredMethod(serviceName, methodName).executableMethod();
+    }
+
+    private GrpcServiceRegistry.RegisteredMethod resolveRegisteredMethod(String serviceName, String methodName) {
+        return registry.getRegisteredMethod(serviceName, methodName)
             .orElseThrow(() -> {
                 LOG.warn("Method '{}' not found in service '{}'", methodName, serviceName);
                 return new MethodNotFoundException(methodName);
             });
+    }
 
-        // Retrieve the bean instance from context
-        Object beanInstance;
+    private Object resolveBeanInstance(String serviceName, ExecutableMethod<?, ?> grpcMethod) {
         try {
-            beanInstance = context.getBean(grpcMethod.getDeclaringType());
+            return context.getBean(grpcMethod.getDeclaringType());
         } catch (Exception e) {
-            // Catching generic Exception might be too broad, consider specific Micronaut exceptions if applicable
             LOG.warn("Service '{}' not found via context for type {}", serviceName, grpcMethod.getDeclaringType().getName(), e);
             throw new ServiceNotFoundException(serviceName);
         }
+    }
 
-        // Transform JSON to Protobuf request
-        // Assuming the request is always the first argument and is a Message
-        @SuppressWarnings("unchecked") Class<? extends Message> requestType = (Class<? extends Message>) grpcMethod.getArguments()[0].getType();
-        Message requestMessage = transcoder.fromJson(jsonRequest, requestType);
-
-        // Invoke method and get potentially multiple Protobuf responses
-        final List<Message> responseMessages;
-        try {
-            //noinspection unchecked
-            responseMessages = invokeGrpcMethodReflectively(beanInstance, (ExecutableMethod<Object, Object>) grpcMethod, requestMessage);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt(); // Re-interrupt the thread
-            throw new GrpcInvocationException("gRPC method invocation was interrupted: " + e.getMessage(), e);
-        }
-
-        // Transform Protobuf responses to JSON
-        if (responseMessages.isEmpty()) {
-            // Handle cases where the stream completes without sending messages
-            // Or potentially unary methods that return void/Empty (though Protobuf usually uses google.protobuf.Empty)
-            // Returning an empty JSON array is consistent for streams.
-            // For unary expecting a response, this might indicate an issue, but we return "[]" for now.
-            return "[]";
-        } else if (responseMessages.size() == 1) {
-            // If only one message was received, return it as a single JSON object
-            // This preserves behavior for standard unary calls.
-            return transcoder.toJson(responseMessages.get(0));
-        } else {
-            // If multiple messages were received (streaming), format as a JSON array
-            List<String> jsonResponses = responseMessages.stream()
-                .map(transcoder::toJson)
-                .collect(Collectors.toList());
-            // Construct the JSON array string
-            return "[" + String.join(",", jsonResponses) + "]";
-        }
+    @SuppressWarnings("unchecked")
+    private Class<? extends Message> resolveRequestType(ExecutableMethod<?, ?> grpcMethod) {
+        return (Class<? extends Message>) grpcMethod.getArguments()[0].getType();
     }
 
     /**

--- a/protobuff-json-support/src/main/java/io/micronaut/protobuf/json/grpc/GrpcProxyService.java
+++ b/protobuff-json-support/src/main/java/io/micronaut/protobuf/json/grpc/GrpcProxyService.java
@@ -143,7 +143,9 @@ public class GrpcProxyService {
             return (Message) registeredMethod.methodDescriptor().getRequestMarshaller()
                 .parse(new ByteArrayInputStream(requestBytes));
         } catch (RuntimeException e) {
-            throw new HttpStatusException(HttpStatus.BAD_REQUEST, "Failed to parse protobuf request: " + e.getMessage());
+            var hse = new HttpStatusException(HttpStatus.BAD_REQUEST, "Failed to parse protobuf request: " + e.getMessage());
+            hse.initCause(e);
+            throw hse;
         }
     }
 

--- a/protobuff-json-support/src/main/java/io/micronaut/protobuf/json/grpc/GrpcProxyService.java
+++ b/protobuff-json-support/src/main/java/io/micronaut/protobuf/json/grpc/GrpcProxyService.java
@@ -18,6 +18,8 @@ package io.micronaut.protobuf.json.grpc;
 import com.google.protobuf.Message;
 import io.grpc.stub.StreamObserver;
 import io.micronaut.context.ApplicationContext;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.exceptions.HttpStatusException;
 import io.micronaut.inject.ExecutableMethod;
 import io.micronaut.protobuf.json.ProtobufJsonTranscoder;
 import io.micronaut.protobuf.json.exception.GrpcInvocationException;
@@ -137,8 +139,12 @@ public class GrpcProxyService {
      */
     public Message parseRequestMessage(String serviceName, String methodName, byte[] requestBytes) {
         GrpcServiceRegistry.RegisteredMethod registeredMethod = resolveRegisteredMethod(serviceName, methodName);
-        return (Message) registeredMethod.methodDescriptor().getRequestMarshaller()
-            .parse(new ByteArrayInputStream(requestBytes));
+        try {
+            return (Message) registeredMethod.methodDescriptor().getRequestMarshaller()
+                .parse(new ByteArrayInputStream(requestBytes));
+        } catch (RuntimeException e) {
+            throw new HttpStatusException(HttpStatus.BAD_REQUEST, "Failed to parse protobuf request: " + e.getMessage());
+        }
     }
 
     private String toJson(List<Message> responseMessages) {

--- a/protobuff-json-support/src/main/java/io/micronaut/protobuf/json/registry/GrpcServiceRegistrar.java
+++ b/protobuff-json-support/src/main/java/io/micronaut/protobuf/json/registry/GrpcServiceRegistrar.java
@@ -81,7 +81,13 @@ public class GrpcServiceRegistrar implements ExecutableMethodProcessor<GrpcRestJ
      */
     @Override
     public <B> void process(BeanDefinition<B> beanDefinition, ExecutableMethod<B, ?> method) {
-        BindableService service = (BindableService) applicationContext.getBean(beanDefinition.getBeanType());
+        Object bean = applicationContext.getBean(beanDefinition.getBeanType());
+        if (!(bean instanceof BindableService service)) {
+            throw new IllegalStateException(
+                "Bean " + beanDefinition.getBeanType().getSimpleName() +
+                    " must implement BindableService to use @GrpcRestJsonExposed"
+            );
+        }
         MethodDescriptor<?, ?> methodDescriptor = service.bindService()
             .getMethods()
             .stream()

--- a/protobuff-json-support/src/main/java/io/micronaut/protobuf/json/registry/GrpcServiceRegistrar.java
+++ b/protobuff-json-support/src/main/java/io/micronaut/protobuf/json/registry/GrpcServiceRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2025 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,9 @@
  */
 package io.micronaut.protobuf.json.registry;
 
+import io.grpc.BindableService;
+import io.grpc.MethodDescriptor;
+import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.processor.ExecutableMethodProcessor;
 import io.micronaut.core.annotation.Experimental;
 import io.micronaut.grpc.annotation.GrpcRestJsonExposed;
@@ -23,6 +26,8 @@ import io.micronaut.inject.ExecutableMethod;
 import jakarta.inject.Singleton;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.beans.Introspector;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -57,9 +62,12 @@ public class GrpcServiceRegistrar implements ExecutableMethodProcessor<GrpcRestJ
 
     private static final Logger LOG = LoggerFactory.getLogger(GrpcServiceRegistrar.class);
     private final GrpcServiceRegistry registry;
+    private final ApplicationContext applicationContext;
 
-    public GrpcServiceRegistrar(GrpcServiceRegistry registry) {
+    public GrpcServiceRegistrar(GrpcServiceRegistry registry,
+                                ApplicationContext applicationContext) {
         this.registry = checkNotNull(registry, "GrpcServiceRegistry cannot be null");
+        this.applicationContext = checkNotNull(applicationContext, "ApplicationContext cannot be null");
     }
 
     /**
@@ -73,8 +81,22 @@ public class GrpcServiceRegistrar implements ExecutableMethodProcessor<GrpcRestJ
      */
     @Override
     public <B> void process(BeanDefinition<B> beanDefinition, ExecutableMethod<B, ?> method) {
+        BindableService service = (BindableService) applicationContext.getBean(beanDefinition.getBeanType());
+        MethodDescriptor<?, ?> methodDescriptor = service.bindService()
+            .getMethods()
+            .stream()
+            .map(definition -> definition.getMethodDescriptor())
+            .filter(descriptor -> matchesMethodName(method.getMethodName(), descriptor))
+            .findFirst()
+            .orElseThrow(() -> new IllegalStateException("No gRPC MethodDescriptor found for " +
+                beanDefinition.getBeanType().getSimpleName() + "." + method.getMethodName()));
         LOG.info("Registering gRPC JSON-exposed method '{}' from bean '{}'",
             method.getMethodName(), beanDefinition.getBeanType().getSimpleName());
-        registry.register(beanDefinition.getBeanType(), method.getMethodName(), method);
+        registry.register(beanDefinition.getBeanType(), method.getMethodName(), method, methodDescriptor);
+    }
+
+    private boolean matchesMethodName(String executableMethodName, MethodDescriptor<?, ?> descriptor) {
+        return executableMethodName.equals(descriptor.getBareMethodName()) ||
+            executableMethodName.equals(Introspector.decapitalize(descriptor.getBareMethodName()));
     }
 }

--- a/protobuff-json-support/src/main/java/io/micronaut/protobuf/json/registry/GrpcServiceRegistry.java
+++ b/protobuff-json-support/src/main/java/io/micronaut/protobuf/json/registry/GrpcServiceRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2025 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package io.micronaut.protobuf.json.registry;
 
+import io.grpc.MethodDescriptor;
 import io.micronaut.core.annotation.Experimental;
 import io.micronaut.inject.ExecutableMethod;
 import jakarta.inject.Singleton;
@@ -45,7 +46,7 @@ import java.util.concurrent.ConcurrentHashMap;
 @Experimental
 public class GrpcServiceRegistry {
 
-    private final Map<String, Map<String, ExecutableMethod<?, ?>>> methods = new ConcurrentHashMap<>();
+    private final Map<String, Map<String, RegisteredMethod>> methods = new ConcurrentHashMap<>();
 
     /**
      * Registers a gRPC service method with the internal registry, allowing it to be exposed
@@ -55,10 +56,14 @@ public class GrpcServiceRegistry {
      * @param serviceBeanType The class type of the gRPC service bean being registered. Must not be null.
      * @param methodName The name of the method in the gRPC service being registered. Must not be null or empty.
      * @param method The {@code ExecutableMethod} representing the method's metadata and logic. Must not be null.
+     * @param methodDescriptor The gRPC {@link MethodDescriptor} for the method. Must not be null.
      */
-    public void register(Class<?> serviceBeanType, String methodName, ExecutableMethod<?, ?> method) {
+    public void register(Class<?> serviceBeanType,
+                         String methodName,
+                         ExecutableMethod<?, ?> method,
+                         MethodDescriptor<?, ?> methodDescriptor) {
         methods.computeIfAbsent(serviceBeanType.getSimpleName(), key -> new ConcurrentHashMap<>())
-            .put(methodName, method);
+            .put(methodName, new RegisteredMethod(method, methodDescriptor));
     }
 
     /**
@@ -71,8 +76,27 @@ public class GrpcServiceRegistry {
      *         if no matching service or method is registered.
      */
     public Optional<ExecutableMethod<?, ?>> getExecutableMethod(String serviceName, String methodName) {
+        return getRegisteredMethod(serviceName, methodName).map(RegisteredMethod::executableMethod);
+    }
+
+    /**
+     * Retrieves a registered gRPC method entry based on the specified service and method name.
+     *
+     * @param serviceName The gRPC service containing the method.
+     * @param methodName The gRPC method name.
+     * @return The registered method entry if present.
+     */
+    public Optional<RegisteredMethod> getRegisteredMethod(String serviceName, String methodName) {
         return Optional.ofNullable(methods.getOrDefault(serviceName, Map.of()).get(methodName));
     }
 
+    /**
+     * Registered gRPC method metadata.
+     *
+     * @param executableMethod The Micronaut executable method.
+     * @param methodDescriptor The gRPC method descriptor.
+     */
+    public record RegisteredMethod(ExecutableMethod<?, ?> executableMethod,
+                                   MethodDescriptor<?, ?> methodDescriptor) {
+    }
 }
-

--- a/protobuff-json-support/src/main/resources/META-INF/io.micronaut.inject.BeanConfiguration
+++ b/protobuff-json-support/src/main/resources/META-INF/io.micronaut.inject.BeanConfiguration
@@ -1,5 +1,6 @@
 io.micronaut.protobuf.json.GrpcJsonConfiguration
 io.micronaut.protobuf.json.GrpcProxyController
+io.micronaut.protobuf.json.GrpcWebController
 io.micronaut.protobuf.json.ProtobufJsonTranscoder
 io.micronaut.protobuf.json.registry.GrpcServiceRegistrar
 io.micronaut.protobuf.json.registry.GrpcServiceRegistry

--- a/protobuff-json-support/src/test/groovy/io/micronaut/protobuf/json/GrpcWebControllerIntegrationSpec.groovy
+++ b/protobuff-json-support/src/test/groovy/io/micronaut/protobuf/json/GrpcWebControllerIntegrationSpec.groovy
@@ -1,0 +1,113 @@
+package io.micronaut.protobuf.json
+
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.example.grpc.HelloRequest
+import org.example.grpc.HelloResponse
+import spock.lang.Specification
+
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+import java.util.Base64
+
+@MicronautTest(environments = ["test"])
+class GrpcWebControllerIntegrationSpec extends Specification {
+
+    private static final String CONTENT_TYPE = "application/grpc-web+proto"
+    private static final String TEXT_CONTENT_TYPE = "application/grpc-web-text+proto"
+
+    @Inject
+    @Client("/")
+    HttpClient httpClient
+
+    def "invoke gRPC service via gRPC-Web"() {
+        given:
+        byte[] requestPayload = frame(HelloRequest.newBuilder()
+                .setName("Micronaut Web")
+                .build()
+                .toByteArray())
+
+        when:
+        HttpResponse<byte[]> response = httpClient.toBlocking().exchange(
+                HttpRequest.POST("/grpc-web/GreeterService/sayHello", requestPayload)
+                        .header("content-type", CONTENT_TYPE)
+                        .header("accept", CONTENT_TYPE)
+                        .header("x-grpc-web", "1"),
+                byte[]
+        )
+
+        then:
+        response.status.code == 200
+        response.header("content-type").startsWith(CONTENT_TYPE)
+
+        and:
+        def frames = readFrames(response.body())
+        frames.size() == 2
+        !frames[0].trailer
+        HelloResponse.parseFrom(frames[0].payload).greeting == "TEST Hello, Micronaut Web"
+        frames[1].trailer
+        new String(frames[1].payload, StandardCharsets.US_ASCII).contains("grpc-status:0")
+    }
+
+    def "invoke gRPC service via base64 gRPC-Web text"() {
+        given:
+        byte[] requestPayload = Base64.encoder.encode(frame(HelloRequest.newBuilder()
+                .setName("Micronaut Text")
+                .build()
+                .toByteArray()))
+
+        when:
+        HttpResponse<byte[]> response = httpClient.toBlocking().exchange(
+                HttpRequest.POST("/grpc-web/GreeterService/sayHello", requestPayload)
+                        .header("content-type", TEXT_CONTENT_TYPE)
+                        .header("accept", TEXT_CONTENT_TYPE)
+                        .header("x-grpc-web", "1"),
+                byte[]
+        )
+
+        then:
+        response.status.code == 200
+        response.header("content-type").startsWith(TEXT_CONTENT_TYPE)
+
+        and:
+        def frames = readFrames(Base64.decoder.decode(response.body()))
+        HelloResponse.parseFrom(frames[0].payload).greeting == "TEST Hello, Micronaut Text"
+        frames[1].trailer
+        new String(frames[1].payload, StandardCharsets.US_ASCII).contains("grpc-status:0")
+    }
+
+    private static byte[] frame(byte[] message) {
+        ByteBuffer buffer = ByteBuffer.allocate(5 + message.length)
+        buffer.put((byte) 0)
+        buffer.putInt(message.length)
+        buffer.put(message)
+        return buffer.array()
+    }
+
+    private static List<GrpcWebFrame> readFrames(byte[] payload) {
+        List<GrpcWebFrame> frames = []
+        ByteBuffer buffer = ByteBuffer.wrap(payload)
+        while (buffer.remaining() > 0) {
+            byte flags = buffer.get()
+            int length = buffer.getInt()
+            byte[] framePayload = new byte[length]
+            buffer.get(framePayload)
+            frames.add(new GrpcWebFrame((flags & 0x80) != 0, framePayload))
+        }
+        return frames
+    }
+
+    private static final class GrpcWebFrame {
+        final boolean trailer
+        final byte[] payload
+
+        GrpcWebFrame(boolean trailer, byte[] payload) {
+            this.trailer = trailer
+            this.payload = payload
+        }
+    }
+}

--- a/protobuff-json-support/src/test/groovy/io/micronaut/protobuf/json/GrpcWebControllerSpec.groovy
+++ b/protobuff-json-support/src/test/groovy/io/micronaut/protobuf/json/GrpcWebControllerSpec.groovy
@@ -1,0 +1,157 @@
+package io.micronaut.protobuf.json
+
+import io.micronaut.http.HttpResponse
+import io.micronaut.protobuf.json.exception.GrpcInvocationException
+import io.micronaut.protobuf.json.exception.MethodNotFoundException
+import io.micronaut.protobuf.json.grpc.GrpcProxyService
+import org.example.grpc.HelloRequest
+import org.example.grpc.HelloResponse
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+import java.util.Base64
+
+class GrpcWebControllerSpec extends Specification {
+
+    GrpcProxyService grpcProxyService = Mock()
+    GrpcWebController controller = new GrpcWebController(grpcProxyService)
+
+    def "maps service lookup failures to grpc status 12"() {
+        given:
+        byte[] payload = frame(HelloRequest.newBuilder().setName("Micronaut").build().toByteArray())
+
+        when:
+        HttpResponse<byte[]> response = controller.invokeMethod("MissingService", "sayHello", payload, GrpcWebController.GRPC_WEB_PROTO)
+
+        then:
+        1 * grpcProxyService.parseRequestMessage("MissingService", "sayHello", _ as byte[]) >> {
+            throw new MethodNotFoundException("sayHello")
+        }
+        0 * grpcProxyService.invokeGrpcMethod(_, _, _)
+
+        and:
+        response.header("grpc-status") == "12"
+        response.header("grpc-message") == "Method 'sayHello' not found"
+        response.header("x-grpc-web") == "1"
+        response.header("trailer") == "grpc-status,grpc-message"
+
+        and:
+        def frames = readFrames(response.body())
+        frames*.trailer == [true]
+        new String(frames[0].payload, StandardCharsets.US_ASCII).contains("grpc-status:12")
+        new String(frames[0].payload, StandardCharsets.US_ASCII).contains("grpc-message:Method 'sayHello' not found")
+    }
+
+    def "maps invocation failures to grpc status 13 and sanitizes grpc-message"() {
+        given:
+        HelloRequest request = HelloRequest.newBuilder().setName("Micronaut").build()
+        byte[] payload = frame(request.toByteArray())
+
+        when:
+        HttpResponse<byte[]> response = controller.invokeMethod("GreeterService", "sayHello", payload, GrpcWebController.GRPC_WEB_PROTO)
+
+        then:
+        1 * grpcProxyService.parseRequestMessage("GreeterService", "sayHello", _ as byte[]) >> request
+        1 * grpcProxyService.invokeGrpcMethod("GreeterService", "sayHello", request) >> {
+            throw new GrpcInvocationException("bad\r\nmessage")
+        }
+
+        and:
+        response.header("grpc-status") == "13"
+        response.header("grpc-message") == "bad  message"
+
+        and:
+        def frames = readFrames(response.body())
+        frames*.trailer == [true]
+        new String(frames[0].payload, StandardCharsets.US_ASCII).contains("grpc-status:13")
+        new String(frames[0].payload, StandardCharsets.US_ASCII).contains("grpc-message:bad  message")
+    }
+
+    @Unroll
+    def "maps malformed request '#scenario' to grpc status 3"() {
+        when:
+        HttpResponse<byte[]> response = controller.invokeMethod("GreeterService", "sayHello", requestBody, contentType)
+
+        then:
+        0 * grpcProxyService._
+
+        and:
+        byte[] encodedBody = contentType == GrpcWebController.GRPC_WEB_TEXT_PROTO ? Base64.decoder.decode(response.body()) : response.body()
+        def frames = readFrames(encodedBody)
+        frames*.trailer == [true]
+        response.header("grpc-status") == "3"
+        response.header("grpc-message") == expectedMessage
+        new String(frames[0].payload, StandardCharsets.US_ASCII).contains("grpc-status:3")
+        new String(frames[0].payload, StandardCharsets.US_ASCII).contains("grpc-message:${expectedMessage}")
+
+        where:
+        scenario             | contentType                            | requestBody                           | expectedMessage
+        "malformed base64"   | GrpcWebController.GRPC_WEB_TEXT_PROTO  | "%%%".getBytes(StandardCharsets.US_ASCII) | "Malformed base64 gRPC-Web request"
+        "short frame"        | GrpcWebController.GRPC_WEB_PROTO       | [0x00, 0x00, 0x00, 0x00] as byte[]    | "gRPC-Web request body is too short"
+        "trailer frame"      | GrpcWebController.GRPC_WEB_PROTO       | frameWithFlag((byte) 0x80, new byte[0]) | "gRPC-Web request must start with a data frame"
+        "compressed frame"   | GrpcWebController.GRPC_WEB_PROTO       | frameWithFlag((byte) 0x01, new byte[0]) | "Compressed gRPC-Web requests are not supported"
+        "length mismatch"    | GrpcWebController.GRPC_WEB_PROTO       | [0x00, 0x00, 0x00, 0x00, 0x01] as byte[] | "Malformed gRPC-Web frame length"
+    }
+
+    def "encodes protobuf responses as grpc-web frames"() {
+        given:
+        HelloRequest request = HelloRequest.newBuilder().setName("Micronaut").build()
+        HelloResponse responseMessage = HelloResponse.newBuilder().setGreeting("Hello Micronaut").build()
+        byte[] payload = frame(request.toByteArray())
+
+        when:
+        HttpResponse<byte[]> response = controller.invokeMethod("GreeterService", "sayHello", payload, GrpcWebController.GRPC_WEB_PROTO)
+
+        then:
+        1 * grpcProxyService.parseRequestMessage("GreeterService", "sayHello", _ as byte[]) >> request
+        1 * grpcProxyService.invokeGrpcMethod("GreeterService", "sayHello", request) >> [responseMessage]
+
+        and:
+        response.header("grpc-status") == "0"
+        def frames = readFrames(response.body())
+        frames*.trailer == [false, true]
+        HelloResponse.parseFrom(frames[0].payload).greeting == "Hello Micronaut"
+        new String(frames[1].payload, StandardCharsets.US_ASCII).contains("grpc-status:0")
+    }
+
+    private static byte[] frame(byte[] message) {
+        ByteBuffer buffer = ByteBuffer.allocate(5 + message.length)
+        buffer.put((byte) 0)
+        buffer.putInt(message.length)
+        buffer.put(message)
+        buffer.array()
+    }
+
+    private static byte[] frameWithFlag(byte flag, byte[] message) {
+        ByteBuffer buffer = ByteBuffer.allocate(5 + message.length)
+        buffer.put(flag)
+        buffer.putInt(message.length)
+        buffer.put(message)
+        buffer.array()
+    }
+
+    private static List<GrpcWebFrame> readFrames(byte[] payload) {
+        List<GrpcWebFrame> frames = []
+        ByteBuffer buffer = ByteBuffer.wrap(payload)
+        while (buffer.remaining() > 0) {
+            byte flags = buffer.get()
+            int length = buffer.getInt()
+            byte[] framePayload = new byte[length]
+            buffer.get(framePayload)
+            frames.add(new GrpcWebFrame((flags & 0x80) != 0, framePayload))
+        }
+        frames
+    }
+
+    private static final class GrpcWebFrame {
+        final boolean trailer
+        final byte[] payload
+
+        GrpcWebFrame(boolean trailer, byte[] payload) {
+            this.trailer = trailer
+            this.payload = payload
+        }
+    }
+}

--- a/protobuff-json-support/src/test/groovy/io/micronaut/protobuf/json/GrpcWebControllerSpec.groovy
+++ b/protobuff-json-support/src/test/groovy/io/micronaut/protobuf/json/GrpcWebControllerSpec.groovy
@@ -60,13 +60,13 @@ class GrpcWebControllerSpec extends Specification {
 
         and:
         response.header("grpc-status") == "13"
-        response.header("grpc-message") == "bad  message"
+        response.header("grpc-message") == "bad%0D%0Amessage"
 
         and:
         def frames = readFrames(response.body())
         frames*.trailer == [true]
         new String(frames[0].payload, StandardCharsets.US_ASCII).contains("grpc-status:13")
-        new String(frames[0].payload, StandardCharsets.US_ASCII).contains("grpc-message:bad  message")
+        new String(frames[0].payload, StandardCharsets.US_ASCII).contains("grpc-message:bad%0D%0Amessage")
     }
 
     @Unroll

--- a/protobuff-json-support/src/test/groovy/io/micronaut/protobuf/json/grpc/GrpcProxyServiceSpec.groovy
+++ b/protobuff-json-support/src/test/groovy/io/micronaut/protobuf/json/grpc/GrpcProxyServiceSpec.groovy
@@ -1,0 +1,53 @@
+package io.micronaut.protobuf.json.grpc
+
+import io.grpc.MethodDescriptor
+import io.grpc.protobuf.ProtoUtils
+import io.micronaut.context.ApplicationContext
+import io.micronaut.inject.ExecutableMethod
+import io.micronaut.protobuf.json.ProtobufJsonTranscoder
+import io.micronaut.protobuf.json.exception.MethodNotFoundException
+import io.micronaut.protobuf.json.registry.GrpcServiceRegistry
+import org.example.grpc.HelloRequest
+import org.example.grpc.HelloResponse
+import spock.lang.Specification
+
+class GrpcProxyServiceSpec extends Specification {
+
+    private static final MethodDescriptor<?, ?> TEST_DESCRIPTOR = MethodDescriptor.newBuilder()
+            .setType(MethodDescriptor.MethodType.UNARY)
+            .setFullMethodName(MethodDescriptor.generateFullMethodName("test.GreeterService", "sayHello"))
+            .setRequestMarshaller(ProtoUtils.marshaller(HelloRequest.getDefaultInstance()))
+            .setResponseMarshaller(ProtoUtils.marshaller(HelloResponse.getDefaultInstance()))
+            .build()
+
+    GrpcServiceRegistry registry = Mock()
+    ApplicationContext applicationContext = Mock()
+    ProtobufJsonTranscoder transcoder = Mock()
+    GrpcProxyService grpcProxyService = new GrpcProxyService(registry, applicationContext, transcoder)
+
+    def "parses protobuf request bytes with the registered method descriptor"() {
+        given:
+        HelloRequest request = HelloRequest.newBuilder().setName("Micronaut").build()
+        ExecutableMethod executableMethod = Mock()
+        def registeredMethod = new GrpcServiceRegistry.RegisteredMethod(executableMethod, TEST_DESCRIPTOR)
+        registry.getRegisteredMethod("GreeterService", "sayHello") >> Optional.of(registeredMethod)
+
+        when:
+        def message = grpcProxyService.parseRequestMessage("GreeterService", "sayHello", request.toByteArray())
+
+        then:
+        message == request
+    }
+
+    def "throws MethodNotFoundException when parsing bytes for an unregistered method"() {
+        given:
+        registry.getRegisteredMethod("GreeterService", "sayHello") >> Optional.empty()
+
+        when:
+        grpcProxyService.parseRequestMessage("GreeterService", "sayHello", HelloRequest.getDefaultInstance().toByteArray())
+
+        then:
+        def e = thrown(MethodNotFoundException)
+        e.message == "Method 'sayHello' not found"
+    }
+}

--- a/protobuff-json-support/src/test/groovy/io/micronaut/protobuf/json/registry/GrpcServiceRegistrarSpec.groovy
+++ b/protobuff-json-support/src/test/groovy/io/micronaut/protobuf/json/registry/GrpcServiceRegistrarSpec.groovy
@@ -1,6 +1,11 @@
 package io.micronaut.protobuf.json.registry
 
 import io.grpc.BindableService
+import io.grpc.MethodDescriptor
+import io.grpc.ServerMethodDefinition
+import io.grpc.ServerServiceDefinition
+import io.grpc.protobuf.ProtoUtils
+import io.grpc.stub.ServerCalls
 import io.micronaut.context.ApplicationContext
 import io.micronaut.core.annotation.AnnotationValue
 import io.micronaut.grpc.annotation.GrpcRestJsonExposed
@@ -8,6 +13,8 @@ import io.micronaut.inject.BeanDefinition
 import io.micronaut.inject.ExecutableMethod
 import io.micronaut.protobuf.grpc.AnotherGrpcService
 import io.micronaut.protobuf.grpc.GreeterService
+import org.example.grpc.HelloRequest
+import org.example.grpc.HelloResponse
 import spock.lang.Specification
 import spock.lang.Subject
 
@@ -55,5 +62,57 @@ class GrpcServiceRegistrarSpec extends Specification {
 
         then:
         1 * registry.register(AnotherGrpcService, 'anotherMethod', executableMethod, _)
+    }
+
+    def "process method annotated with exact grpc descriptor name"() {
+        given:
+        def methodDescriptor = MethodDescriptor.newBuilder()
+                .setType(MethodDescriptor.MethodType.UNARY)
+                .setFullMethodName(MethodDescriptor.generateFullMethodName("test.CustomService", "SayHello"))
+                .setRequestMarshaller(ProtoUtils.marshaller(HelloRequest.getDefaultInstance()))
+                .setResponseMarshaller(ProtoUtils.marshaller(HelloResponse.getDefaultInstance()))
+                .build()
+        def serviceDefinition = ServerServiceDefinition.builder("test.CustomService")
+                .addMethod(ServerMethodDefinition.create(methodDescriptor, ServerCalls.asyncUnaryCall { request, responseObserver ->
+                    responseObserver.onCompleted()
+                }))
+                .build()
+        def beanDefinition = Mock(BeanDefinition) {
+            getBeanType() >> BindableService
+        }
+        def service = Mock(BindableService) {
+            bindService() >> serviceDefinition
+        }
+        def executableMethod = Mock(ExecutableMethod) {
+            getMethodName() >> 'SayHello'
+            getAnnotation(GrpcRestJsonExposed) >> Optional.of(AnnotationValue.builder(GrpcRestJsonExposed).build())
+        }
+        applicationContext.getBean(BindableService) >> service
+
+        when:
+        registrar.process(beanDefinition, executableMethod)
+
+        then:
+        1 * registry.register(BindableService, 'SayHello', executableMethod, methodDescriptor)
+    }
+
+    def "throws when no grpc descriptor matches the executable method name"() {
+        given:
+        def beanDefinition = Mock(BeanDefinition) {
+            getBeanType() >> GreeterService
+        }
+        def service = new GreeterService()
+        def executableMethod = Mock(ExecutableMethod) {
+            getMethodName() >> 'missingMethod'
+            getAnnotation(GrpcRestJsonExposed) >> Optional.of(AnnotationValue.builder(GrpcRestJsonExposed).build())
+        }
+        applicationContext.getBean(GreeterService) >> service
+
+        when:
+        registrar.process(beanDefinition, executableMethod)
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message == 'No gRPC MethodDescriptor found for GreeterService.missingMethod'
     }
 }

--- a/protobuff-json-support/src/test/groovy/io/micronaut/protobuf/json/registry/GrpcServiceRegistrarSpec.groovy
+++ b/protobuff-json-support/src/test/groovy/io/micronaut/protobuf/json/registry/GrpcServiceRegistrarSpec.groovy
@@ -1,5 +1,7 @@
 package io.micronaut.protobuf.json.registry
 
+import io.grpc.BindableService
+import io.micronaut.context.ApplicationContext
 import io.micronaut.core.annotation.AnnotationValue
 import io.micronaut.grpc.annotation.GrpcRestJsonExposed
 import io.micronaut.inject.BeanDefinition
@@ -12,25 +14,28 @@ import spock.lang.Subject
 class GrpcServiceRegistrarSpec extends Specification {
 
     GrpcServiceRegistry registry = Mock()
+    ApplicationContext applicationContext = Mock()
 
     @Subject
-    GrpcServiceRegistrar registrar = new GrpcServiceRegistrar(registry)
+    GrpcServiceRegistrar registrar = new GrpcServiceRegistrar(registry, applicationContext)
 
     def "process method annotated with GrpcRestJsonExposed"() {
         given:
         def beanDefinition = Mock(BeanDefinition) {
             getBeanType() >> GreeterService
         }
+        def service = new GreeterService()
         def executableMethod = Mock(ExecutableMethod) {
             getMethodName() >> 'sayHello'
             getAnnotation(GrpcRestJsonExposed) >> Optional.of(AnnotationValue.builder(GrpcRestJsonExposed).build())
         }
+        applicationContext.getBean(GreeterService) >> service
 
         when:
         registrar.process(beanDefinition, executableMethod)
 
         then:
-        1 * registry.register(GreeterService, 'sayHello', executableMethod)
+        1 * registry.register(GreeterService, 'sayHello', executableMethod, _)
     }
 
     def "should register method from another service"() {
@@ -38,15 +43,17 @@ class GrpcServiceRegistrarSpec extends Specification {
         def beanDefinition = Mock(BeanDefinition) {
             getBeanType() >> AnotherGrpcService
         }
+        def service = new AnotherGrpcService()
         def executableMethod = Mock(ExecutableMethod) {
             getMethodName() >> 'anotherMethod'
             getAnnotation(GrpcRestJsonExposed) >> Optional.of(AnnotationValue.builder(GrpcRestJsonExposed).build())
         }
+        applicationContext.getBean(AnotherGrpcService) >> service
 
         when:
         registrar.process(beanDefinition, executableMethod)
 
         then:
-        1 * registry.register(AnotherGrpcService, 'anotherMethod', executableMethod)
+        1 * registry.register(AnotherGrpcService, 'anotherMethod', executableMethod, _)
     }
 }

--- a/protobuff-json-support/src/test/groovy/io/micronaut/protobuf/json/registry/GrpcServiceRegistrySpec.groovy
+++ b/protobuff-json-support/src/test/groovy/io/micronaut/protobuf/json/registry/GrpcServiceRegistrySpec.groovy
@@ -1,10 +1,21 @@
 package io.micronaut.protobuf.json.registry
 
+import io.grpc.MethodDescriptor
+import io.grpc.protobuf.ProtoUtils
 import io.micronaut.inject.ExecutableMethod
+import org.example.grpc.HelloRequest
+import org.example.grpc.HelloResponse
 import spock.lang.Specification
 import spock.lang.Subject
 
 class GrpcServiceRegistrySpec extends Specification {
+
+    private static final MethodDescriptor<?, ?> TEST_DESCRIPTOR = MethodDescriptor.newBuilder()
+            .setType(MethodDescriptor.MethodType.UNARY)
+            .setFullMethodName(MethodDescriptor.generateFullMethodName("test.TestService", "testMethod"))
+            .setRequestMarshaller(ProtoUtils.marshaller(HelloRequest.getDefaultInstance()))
+            .setResponseMarshaller(ProtoUtils.marshaller(HelloResponse.getDefaultInstance()))
+            .build()
 
     @Subject
     GrpcServiceRegistry registry = new GrpcServiceRegistry()
@@ -17,7 +28,7 @@ class GrpcServiceRegistrySpec extends Specification {
         }
 
         when:
-        registry.register(TestService.class, "testMethod", executableMethod)
+        registry.register(TestService.class, "testMethod", executableMethod, TEST_DESCRIPTOR)
         def result = registry.getExecutableMethod("TestService", "testMethod")
 
         then:
@@ -45,14 +56,26 @@ class GrpcServiceRegistrySpec extends Specification {
         }
 
         when:
-        registry.register(TestService.class, "method1", method1)
-        registry.register(AnotherTestService.class, "method2", method2)
+        registry.register(TestService.class, "method1", method1, TEST_DESCRIPTOR)
+        registry.register(AnotherTestService.class, "method2", method2, TEST_DESCRIPTOR)
 
         then:
         registry.getExecutableMethod("TestService", "method1").isPresent()
         registry.getExecutableMethod("AnotherTestService", "method2").isPresent()
         registry.getExecutableMethod("TestService", "method1").get() == method1
         registry.getExecutableMethod("AnotherTestService", "method2").get() == method2
+    }
+
+    def "should return registered method descriptor"() {
+        given:
+        ExecutableMethod executableMethod = Mock(ExecutableMethod)
+
+        when:
+        registry.register(TestService.class, "testMethod", executableMethod, TEST_DESCRIPTOR)
+
+        then:
+        registry.getRegisteredMethod("TestService", "testMethod").present
+        registry.getRegisteredMethod("TestService", "testMethod").get().methodDescriptor() == TEST_DESCRIPTOR
     }
 
     static class TestService {

--- a/src/main/docs/guide/grpcWeb.adoc
+++ b/src/main/docs/guide/grpcWeb.adoc
@@ -37,12 +37,12 @@ For the sample `GreeterService#sayHello` method this becomes:
 
 The path prefix defaults to `grpc-web` and can be changed with:
 
-[configuration]
+[source,yaml]
 ----
 micronaut:
-  grpc:
-    web:
-      path: custom-grpc-web
+    grpc:
+        web:
+            path: custom-grpc-web
 ----
 
 == Supported Content Types

--- a/src/main/docs/guide/grpcWeb.adoc
+++ b/src/main/docs/guide/grpcWeb.adoc
@@ -1,0 +1,89 @@
+= gRPC-Web
+
+Micronaut can also expose `@GrpcRestJsonExposed` methods through the gRPC-Web wire protocol over HTTP/1.1.
+
+This is useful when a browser or browser-facing proxy needs protobuf-native unary calls instead of the JSON transcoding endpoint described in xref:protocolBuffersJsonSupport.adoc[Protocol Buffers Json Support].
+
+== Setup
+
+Add the JSON support module:
+
+dependency:micronaut-protobuff-json-support[groupId="io.micronaut.grpc"]
+
+Then annotate the gRPC service method you want to expose:
+
+[source,java]
+----
+include::test-suite-protobuff-json-java/src/main/java/com/example/services/GreeterService.java[]
+----
+
+The same annotation enables both:
+
+- the JSON endpoint at `/grpc-json/{serviceName}/{method}`
+- the gRPC-Web endpoint at `/grpc-web/{serviceName}/{method}`
+
+== Endpoint Shape
+
+Unary gRPC-Web requests are served from:
+
+[source]
+----
+/grpc-web/{serviceName}/{method}
+----
+
+For the sample `GreeterService#sayHello` method this becomes:
+
+`http://localhost:8080/grpc-web/GreeterService/sayHello`
+
+The path prefix defaults to `grpc-web` and can be changed with:
+
+[configuration]
+----
+micronaut:
+  grpc:
+    web:
+      path: custom-grpc-web
+----
+
+== Supported Content Types
+
+The endpoint accepts and returns:
+
+- `application/grpc-web+proto`
+- `application/grpc-web-text+proto`
+
+Binary requests use the standard gRPC-Web frame format.
+Text requests use the same frames, base64-encoded for browser compatibility.
+
+== Request Format
+
+Each request body must contain a framed protobuf message:
+
+1. One byte of flags.
+2. Four bytes of message length.
+3. The serialized protobuf payload.
+
+The current implementation supports unary requests with an uncompressed data frame.
+Compressed request frames are rejected.
+
+== Response Format
+
+Successful responses include:
+
+- one protobuf data frame containing the unary response message
+- one trailers frame containing `grpc-status: 0`
+
+Error responses are still returned using gRPC-Web framing and include trailer metadata such as `grpc-status` and `grpc-message`.
+
+== Example Flow
+
+With this proto definition:
+
+[source,protobuf]
+----
+include::test-suite-protobuff-json-java/src/main/proto/greeter.proto[]
+----
+
+the gRPC-Web endpoint expects a framed `HelloRequest` protobuf payload and returns a framed `HelloResponse` protobuf payload.
+
+In practice, a browser application will usually rely on a gRPC-Web client library or proxy to construct these frames rather than building them manually.

--- a/src/main/docs/guide/protocolBuffersJsonSupport.adoc
+++ b/src/main/docs/guide/protocolBuffersJsonSupport.adoc
@@ -15,6 +15,7 @@ include::test-suite-protobuff-json-java/src/main/java/com/example/services/Greet
 ----
 
 Micronaut will now support the encoding and decoding requests / responses of type `application/json` via http 1.1.
+For browser-oriented gRPC-Web support, see the dedicated guide section at xref:grpcWeb.adoc[gRPC-Web].
 
 == How this works
 
@@ -75,7 +76,4 @@ curl -X POST http://localhost:8080/grpc-json/GreeterService/sayHello \
 -H "Content-Type: application/json" \
 -d '{"name": "YourName"}'
 ----
-
-
-
 

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -8,4 +8,5 @@ serviceDiscovery: Service Discovery
 tracing: Distributed Tracing
 protocolBuffers: Protocol Buffers Support
 protocolBuffersJsonSupport: Protocol Buffers Json Support (Experimental)
+grpcWeb: gRPC-Web
 repository: Repository


### PR DESCRIPTION
## Summary
- add experimental unary gRPC-Web HTTP endpoints for `@GrpcRestJsonExposed` services
- replace reflective protobuf request parsing with gRPC `MethodDescriptor` marshallers
- document gRPC-Web in its own top-level guide section

## Verification
- `./gradlew :micronaut-protobuff-json-support:test`
- `./gradlew publishGuide`
- `./gradlew docs`

Resolves #252
