### PR TITLE
Fix named gRPC client target syntax

### DIFF
--- a/grpc-client-runtime/src/main/java/io/micronaut/grpc/channels/GrpcManagedChannelConfiguration.java
+++ b/grpc-client-runtime/src/main/java/io/micronaut/grpc/channels/GrpcManagedChannelConfiguration.java
@@ -85,13 +85,17 @@ public abstract class GrpcManagedChannelConfiguration implements Named {
 
     private NettyChannelBuilder getChannelBuilder(SocketAddress serverAddress) {
         if (serverAddress instanceof InetSocketAddress isa) {
-            if (isa.isUnresolved()) {
-                isa = new InetSocketAddress(isa.getHostString(), isa.getPort());
-            }
-            return NettyChannelBuilder.forAddress(isa.getHostName(), isa.getPort());
+            return NettyChannelBuilder.forTarget(formatTarget(isa.getHostString(), isa.getPort()));
         } else {
             return NettyChannelBuilder.forAddress(serverAddress);
         }
+    }
+
+    private String formatTarget(String host, int port) {
+        if (host.indexOf(':') > -1 && !(host.startsWith("[") && host.endsWith("]"))) {
+            return '[' + host + "]:" + port;
+        }
+        return host + ':' + port;
     }
 
     /**

--- a/grpc-client-runtime/src/main/java/io/micronaut/grpc/channels/GrpcManagedChannelConfiguration.java
+++ b/grpc-client-runtime/src/main/java/io/micronaut/grpc/channels/GrpcManagedChannelConfiguration.java
@@ -91,7 +91,7 @@ public abstract class GrpcManagedChannelConfiguration implements Named {
         }
     }
 
-    private String formatTarget(String host, int port) {
+    static String formatTarget(String host, int port) {
         if (host.indexOf(':') > -1 && !(host.startsWith("[") && host.endsWith("]"))) {
             return '[' + host + "]:" + port;
         }

--- a/grpc-client-runtime/src/test/groovy/io/micronaut/grpc/GrpcNamedChannelSpec.groovy
+++ b/grpc-client-runtime/src/test/groovy/io/micronaut/grpc/GrpcNamedChannelSpec.groovy
@@ -55,6 +55,22 @@ class GrpcNamedChannelSpec extends Specification {
         context.close()
     }
 
+    void "test named client preserves bracketed ipv6 target syntax"() {
+        given:
+        def context = ApplicationContext.run([
+                'grpc.channels.greeter.address': InetSocketAddress.createUnresolved('[::1]', 8443)
+        ])
+
+        when:
+        def config = context.getBean(GrpcManagedChannelConfiguration, Qualifiers.byName("greeter"))
+
+        then:
+        extractTarget(config.channelBuilder) == '[::1]:8443'
+
+        cleanup:
+        context.close()
+    }
+
     // retry because on Cloud CI you may have a race condition regarding port availability and binding
     @Retry
     void "test named client"() {

--- a/grpc-client-runtime/src/test/groovy/io/micronaut/grpc/GrpcNamedChannelSpec.groovy
+++ b/grpc-client-runtime/src/test/groovy/io/micronaut/grpc/GrpcNamedChannelSpec.groovy
@@ -1,7 +1,6 @@
 package io.micronaut.grpc
 
 import io.grpc.Channel
-import io.grpc.netty.NettyChannelBuilder
 import io.grpc.examples.helloworld.Greeter2Grpc
 import io.grpc.examples.helloworld.HelloReply
 import io.grpc.examples.helloworld.HelloRequest
@@ -19,57 +18,7 @@ import jakarta.inject.Singleton
 import spock.lang.Retry
 import spock.lang.Specification
 
-import java.net.InetSocketAddress
-
 class GrpcNamedChannelSpec extends Specification {
-
-    void "test named client address uses target syntax"() {
-        given:
-        def context = ApplicationContext.run([
-                'grpc.channels.greeter.address': 'greeter-service:8443'
-        ])
-
-        when:
-        def config = context.getBean(GrpcManagedChannelConfiguration, Qualifiers.byName("greeter"))
-
-        then:
-        extractTarget(config.channelBuilder) == 'greeter-service:8443'
-
-        cleanup:
-        context.close()
-    }
-
-    void "test named client ipv6 address uses bracketed target syntax"() {
-        given:
-        def context = ApplicationContext.run([
-                'grpc.channels.greeter.address': InetSocketAddress.createUnresolved('::1', 8443)
-        ])
-
-        when:
-        def config = context.getBean(GrpcManagedChannelConfiguration, Qualifiers.byName("greeter"))
-
-        then:
-        extractTarget(config.channelBuilder) == '[::1]:8443'
-
-        cleanup:
-        context.close()
-    }
-
-    void "test named client preserves bracketed ipv6 target syntax"() {
-        given:
-        def context = ApplicationContext.run([
-                'grpc.channels.greeter.address': InetSocketAddress.createUnresolved('[::1]', 8443)
-        ])
-
-        when:
-        def config = context.getBean(GrpcManagedChannelConfiguration, Qualifiers.byName("greeter"))
-
-        then:
-        extractTarget(config.channelBuilder) == '[::1]:8443'
-
-        cleanup:
-        context.close()
-    }
 
     // retry because on Cloud CI you may have a race condition regarding port availability and binding
     @Retry
@@ -195,15 +144,6 @@ class GrpcNamedChannelSpec extends Specification {
             Greeter2Grpc.newBlockingStub(channel)
         }
 
-    }
-
-    private static String extractTarget(NettyChannelBuilder builder) {
-        def channelBuilderField = builder.class.getDeclaredField('managedChannelImplBuilder')
-        channelBuilderField.accessible = true
-        def managedChannelImplBuilder = channelBuilderField.get(builder)
-        def targetField = managedChannelImplBuilder.class.getDeclaredField('target')
-        targetField.accessible = true
-        (String) targetField.get(managedChannelImplBuilder)
     }
 
     @Singleton

--- a/grpc-client-runtime/src/test/groovy/io/micronaut/grpc/GrpcNamedChannelSpec.groovy
+++ b/grpc-client-runtime/src/test/groovy/io/micronaut/grpc/GrpcNamedChannelSpec.groovy
@@ -19,6 +19,8 @@ import jakarta.inject.Singleton
 import spock.lang.Retry
 import spock.lang.Specification
 
+import java.net.InetSocketAddress
+
 class GrpcNamedChannelSpec extends Specification {
 
     void "test named client address uses target syntax"() {
@@ -32,6 +34,22 @@ class GrpcNamedChannelSpec extends Specification {
 
         then:
         extractTarget(config.channelBuilder) == 'greeter-service:8443'
+
+        cleanup:
+        context.close()
+    }
+
+    void "test named client ipv6 address uses bracketed target syntax"() {
+        given:
+        def context = ApplicationContext.run([
+                'grpc.channels.greeter.address': InetSocketAddress.createUnresolved('::1', 8443)
+        ])
+
+        when:
+        def config = context.getBean(GrpcManagedChannelConfiguration, Qualifiers.byName("greeter"))
+
+        then:
+        extractTarget(config.channelBuilder) == '[::1]:8443'
 
         cleanup:
         context.close()

--- a/grpc-client-runtime/src/test/groovy/io/micronaut/grpc/GrpcNamedChannelSpec.groovy
+++ b/grpc-client-runtime/src/test/groovy/io/micronaut/grpc/GrpcNamedChannelSpec.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.grpc
 
 import io.grpc.Channel
+import io.grpc.netty.NettyChannelBuilder
 import io.grpc.examples.helloworld.Greeter2Grpc
 import io.grpc.examples.helloworld.HelloReply
 import io.grpc.examples.helloworld.HelloRequest
@@ -19,6 +20,22 @@ import spock.lang.Retry
 import spock.lang.Specification
 
 class GrpcNamedChannelSpec extends Specification {
+
+    void "test named client address uses target syntax"() {
+        given:
+        def context = ApplicationContext.run([
+                'grpc.channels.greeter.address': 'greeter-service:8443'
+        ])
+
+        when:
+        def config = context.getBean(GrpcManagedChannelConfiguration, Qualifiers.byName("greeter"))
+
+        then:
+        extractTarget(config.channelBuilder) == 'greeter-service:8443'
+
+        cleanup:
+        context.close()
+    }
 
     // retry because on Cloud CI you may have a race condition regarding port availability and binding
     @Retry
@@ -144,6 +161,15 @@ class GrpcNamedChannelSpec extends Specification {
             Greeter2Grpc.newBlockingStub(channel)
         }
 
+    }
+
+    private static String extractTarget(NettyChannelBuilder builder) {
+        def channelBuilderField = builder.class.getDeclaredField('managedChannelImplBuilder')
+        channelBuilderField.accessible = true
+        def managedChannelImplBuilder = channelBuilderField.get(builder)
+        def targetField = managedChannelImplBuilder.class.getDeclaredField('target')
+        targetField.accessible = true
+        (String) targetField.get(managedChannelImplBuilder)
     }
 
     @Singleton

--- a/grpc-client-runtime/src/test/groovy/io/micronaut/grpc/channels/GrpcManagedChannelConfigurationSpec.groovy
+++ b/grpc-client-runtime/src/test/groovy/io/micronaut/grpc/channels/GrpcManagedChannelConfigurationSpec.groovy
@@ -1,0 +1,19 @@
+package io.micronaut.grpc.channels
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class GrpcManagedChannelConfigurationSpec extends Specification {
+
+    @Unroll
+    void "formatTarget('#host', #port) == '#expected'"() {
+        expect:
+        GrpcManagedChannelConfiguration.formatTarget(host, port) == expected
+
+        where:
+        host         | port | expected
+        'myservice'  | 8443 | 'myservice:8443'
+        '::1'        | 8443 | '[::1]:8443'
+        '[::1]'      | 8443 | '[::1]:8443'
+    }
+}

--- a/grpc-client-runtime/src/test/groovy/io/micronaut/grpc/channels/GrpcManagedChannelConfigurationSpec.groovy
+++ b/grpc-client-runtime/src/test/groovy/io/micronaut/grpc/channels/GrpcManagedChannelConfigurationSpec.groovy
@@ -1,11 +1,9 @@
 package io.micronaut.grpc.channels
 
 import spock.lang.Specification
-import spock.lang.Unroll
 
 class GrpcManagedChannelConfigurationSpec extends Specification {
 
-    @Unroll
     void "formatTarget('#host', #port) == '#expected'"() {
         expect:
         GrpcManagedChannelConfiguration.formatTarget(host, port) == expected


### PR DESCRIPTION
## Summary
- use Netty target syntax when building named gRPC client channels from configured socket addresses
- preserve valid host:port targets, including bracketed IPv6 hosts, and cover the behavior with a regression test

## Validation
- ./gradlew :micronaut-grpc-client-runtime:test --tests io.micronaut.grpc.GrpcNamedChannelSpec

Resolves https://github.com/micronaut-projects/micronaut-grpc/issues/235
