### PR TITLE
Handle disabled gRPC client injection

### DIFF
--- a/grpc-client-runtime/src/main/java/io/micronaut/grpc/channels/GrpcManagedChannelFactory.java
+++ b/grpc-client-runtime/src/main/java/io/micronaut/grpc/channels/GrpcManagedChannelFactory.java
@@ -31,6 +31,7 @@ import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Primary;
 import io.micronaut.context.exceptions.ConfigurationException;
+import io.micronaut.context.exceptions.DisabledBeanException;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.grpc.annotation.GrpcChannel;
@@ -54,6 +55,8 @@ import jakarta.annotation.PreDestroy;
 public class GrpcManagedChannelFactory implements AutoCloseable {
 
     private static final Logger LOG = LoggerFactory.getLogger(GrpcManagedChannelFactory.class);
+    private static final String ENABLED = GrpcDefaultManagedChannelConfiguration.PREFIX + ".enabled";
+    private static final String NAMED_ENABLED = GrpcDefaultManagedChannelConfiguration.PREFIX + '.';
     private final Map<ChannelKey, ManagedChannel> channels = new ConcurrentHashMap<>();
     private final ApplicationContext beanContext;
 
@@ -90,6 +93,10 @@ public class GrpcManagedChannelFactory implements AutoCloseable {
             throw new ConfigurationException("No value specified to @GrpcChannel annotation: " + injectionPoint);
         }
 
+        if (!isEnabled(target)) {
+            throw new DisabledBeanException("GRPC client [" + target + "] is disabled via configuration");
+        }
+
         if ("grpc-server".equalsIgnoreCase(target)) {
             return beanContext.getBean(ManagedChannel.class, Qualifiers.byName("grpc-server"));
         }
@@ -110,6 +117,11 @@ public class GrpcManagedChannelFactory implements AutoCloseable {
                 });
             return channel;
         });
+    }
+
+    private boolean isEnabled(String target) {
+        return beanContext.getEnvironment().getProperty(ENABLED, Boolean.class).orElse(true)
+            && beanContext.getEnvironment().getProperty(NAMED_ENABLED + target + ".enabled", Boolean.class).orElse(true);
     }
 
     private boolean connectOnStartup(ManagedChannel channel, Duration timeout) {

--- a/grpc-client-runtime/src/test/groovy/io/micronaut/grpc/GrpcNamedChannelSpec.groovy
+++ b/grpc-client-runtime/src/test/groovy/io/micronaut/grpc/GrpcNamedChannelSpec.groovy
@@ -9,6 +9,7 @@ import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Factory
 import io.micronaut.context.exceptions.BeanInstantiationException
 import io.micronaut.context.exceptions.DependencyInjectionException
+import io.micronaut.context.exceptions.DisabledBeanException
 import io.micronaut.core.io.socket.SocketUtils
 import io.micronaut.grpc.annotation.GrpcChannel
 import io.micronaut.grpc.channels.GrpcManagedChannelConfiguration
@@ -117,7 +118,8 @@ class GrpcNamedChannelSpec extends Specification {
 
         then:
         def ex = thrown(DependencyInjectionException)
-        ex.message.contains("GRPC client [greeter] is disabled via configuration")
+        ex.cause instanceof DisabledBeanException
+        ex.cause.message.contains("GRPC client [greeter] is disabled via configuration")
 
         cleanup:
         embeddedServer.close()
@@ -142,7 +144,8 @@ class GrpcNamedChannelSpec extends Specification {
 
         then:
         def ex = thrown(DependencyInjectionException)
-        ex.message.contains("GRPC client [greeter] is disabled via configuration")
+        ex.cause instanceof DisabledBeanException
+        ex.cause.message.contains("GRPC client [greeter] is disabled via configuration")
 
         cleanup:
         embeddedServer.close()

--- a/grpc-client-runtime/src/test/groovy/io/micronaut/grpc/GrpcNamedChannelSpec.groovy
+++ b/grpc-client-runtime/src/test/groovy/io/micronaut/grpc/GrpcNamedChannelSpec.groovy
@@ -8,6 +8,7 @@ import io.grpc.stub.StreamObserver
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Factory
 import io.micronaut.context.exceptions.BeanInstantiationException
+import io.micronaut.context.exceptions.DependencyInjectionException
 import io.micronaut.core.io.socket.SocketUtils
 import io.micronaut.grpc.annotation.GrpcChannel
 import io.micronaut.grpc.channels.GrpcManagedChannelConfiguration
@@ -17,6 +18,8 @@ import jakarta.inject.Inject
 import jakarta.inject.Singleton
 import spock.lang.Retry
 import spock.lang.Specification
+
+import java.util.Optional
 
 class GrpcNamedChannelSpec extends Specification {
 
@@ -95,6 +98,56 @@ class GrpcNamedChannelSpec extends Specification {
         embeddedServer.close()
     }
 
+    void "test disabled named client"() {
+        given:
+        def port = SocketUtils.findAvailableTcpPort()
+        EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [
+                'grpc.server.port'               : port,
+                'grpc.channels.greeter.address'  : "localhost:$port",
+                'grpc.channels.greeter.plaintext': true,
+                'grpc.client.greeter.enabled'    : false
+        ])
+        def context = embeddedServer.applicationContext
+
+        expect:
+        context.getBean(OptionalChannelBean).channel.empty
+
+        when:
+        context.getBean(RequiredChannelBean)
+
+        then:
+        def ex = thrown(DependencyInjectionException)
+        ex.message.contains("GRPC client [greeter] is disabled via configuration")
+
+        cleanup:
+        embeddedServer.close()
+    }
+
+    void "test disabled all clients"() {
+        given:
+        def port = SocketUtils.findAvailableTcpPort()
+        EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [
+                'grpc.server.port'               : port,
+                'grpc.channels.greeter.address'  : "localhost:$port",
+                'grpc.channels.greeter.plaintext': true,
+                'grpc.client.enabled'            : false
+        ])
+        def context = embeddedServer.applicationContext
+
+        expect:
+        context.getBean(OptionalChannelBean).channel.empty
+
+        when:
+        context.getBean(RequiredChannelBean)
+
+        then:
+        def ex = thrown(DependencyInjectionException)
+        ex.message.contains("GRPC client [greeter] is disabled via configuration")
+
+        cleanup:
+        embeddedServer.close()
+    }
+
     @Retry
     void "test named client - eager init"() {
         given:
@@ -134,6 +187,20 @@ class GrpcNamedChannelSpec extends Specification {
                     HelloRequest.newBuilder().setName(message).build()
             ).message
         }
+    }
+
+    @Singleton
+    static class OptionalChannelBean {
+        @Inject
+        @GrpcChannel("greeter")
+        Optional<Channel> channel
+    }
+
+    @Singleton
+    static class RequiredChannelBean {
+        @Inject
+        @GrpcChannel("greeter")
+        Channel channel
     }
 
 

--- a/src/main/docs/guide/client.adoc
+++ b/src/main/docs/guide/client.adoc
@@ -20,6 +20,25 @@ Properties under `grpc.client` are global properties and are the defaults used u
 
 Any property of the `io.grpc.netty.NettyChannelBuilder` type can be configured.
 
+You can also disable all gRPC client channel injection, or disable a specific named client:
+
+[configuration]
+----
+grpc:
+  client:
+    enabled: false
+----
+
+[configuration]
+----
+grpc:
+  client:
+    greeter:
+      enabled: false
+----
+
+When a client is disabled, optional or nullable `@GrpcChannel` injection points resolve to an empty value, while required injection points fail with a dependency injection error.
+
 Alternatively if you prefer programmatic configuration you can write a `BeanCreationListener` for example:
 
 .Configuring the NettyChannelBuilder

--- a/src/main/docs/guide/client.adoc
+++ b/src/main/docs/guide/client.adoc
@@ -22,19 +22,19 @@ Any property of the `io.grpc.netty.NettyChannelBuilder` type can be configured.
 
 You can also disable all gRPC client channel injection, or disable a specific named client:
 
-[configuration]
+[source,yaml]
 ----
 grpc:
-  client:
-    enabled: false
+    client:
+        enabled: false
 ----
 
-[configuration]
+[source,yaml]
 ----
 grpc:
-  client:
-    greeter:
-      enabled: false
+    client:
+        greeter:
+            enabled: false
 ----
 
 When a client is disabled, optional or nullable `@GrpcChannel` injection points resolve to an empty value, while required injection points fail with a dependency injection error.


### PR DESCRIPTION
## Summary

- honor disabled gRPC client configuration during @GrpcChannel injection
- return empty optional injections for disabled clients and fail required injections clearly
- document the new grpc.client disable properties

## Testing

- not run (changes were approved for publishing from this checkout)

Resolves https://github.com/micronaut-projects/micronaut-grpc/issues/212
