### PR TITLE
Replace YAML source blocks with configuration macro

### DIFF
--- a/src/main/docs/guide/client.adoc
+++ b/src/main/docs/guide/client.adoc
@@ -8,7 +8,7 @@ The channel can be configured using properties defined under `grpc.client` by de
 
 For example, if you wish to disable secure communication:
 
-[source,yaml]
+[configuration]
 ----
 grpc:
     client:
@@ -58,7 +58,7 @@ The above example requires that `my.server` and `my.port` are specified in `appl
 
 For example given the following configuration:
 
-[source,yaml]
+[configuration]
 ----
 grpc:
     channels:

--- a/src/main/docs/guide/server.adoc
+++ b/src/main/docs/guide/server.adoc
@@ -31,7 +31,7 @@ The server can be configured in a number of different ways. By default, Micronau
 For example:
 
 .Configuring the gRPC server
-[source,yaml]
+[configuration]
 ----
 grpc:
     server:
@@ -50,7 +50,7 @@ By default, the gRPC server will be enabled. To disable the gRPC server, set `gr
 For tests, add the `io.micronaut.grpc:micronaut-grpc-inprocess` module and set `grpc.server.in-process-name` to switch the embedded server and the injected `@GrpcChannel("grpc-server")` test channel to gRPC's in-process transport instead of opening a TCP port.
 
 .Using the in-process server for tests
-[source,yaml]
+[configuration]
 ----
 grpc:
     server:

--- a/src/main/docs/guide/serviceDiscovery.adoc
+++ b/src/main/docs/guide/serviceDiscovery.adoc
@@ -25,7 +25,7 @@ dependency:micronaut-discovery-client[groupId="io.micronaut.discovery", scope="r
 
 Then setup Consul correctly:
 
-[source,yaml]
+[configuration]
 ----
 micronaut:
     application:
@@ -41,7 +41,7 @@ When using Service Discovery, Micronaut will register the service in Consul usin
 If the application also uses an HTTP Server (Netty, Tomcat,...), Micronaut will register the application with the same
 name and a different port in Consul. In case you want to use a different name for the gRPC service in Consul:
 
-[source,yaml]
+[configuration]
 ----
 micronaut:
     application:
@@ -58,7 +58,7 @@ grpc:
 
 To discovery services via Consul and the Micronaut `DiscoveryClient` abstraction enable Consul and gRPC service discovery:
 
-[source,yaml]
+[configuration]
 ----
 grpc:
     client:


### PR DESCRIPTION
## Summary
- replace YAML source blocks in gRPC guide configuration examples with the configuration macro
- keep the existing YAML snippets unchanged

## Verification
- rg -n "\[source,yaml\]" src/main/docs/guide
- git diff --check
- ./gradlew publishGuide
- ./gradlew docs

Resolves https://github.com/micronaut-projects/micronaut-grpc/issues/1203
